### PR TITLE
fix: update canonical URLs to use www versions

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,19 +10,19 @@
     <meta name="robots" content="index, follow">
     <meta name="googlebot" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1">
     <meta name="bingbot" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1">
-    <link rel="canonical" href="https://essentials.com/">
-    <link rel="alternate" hreflang="en" href="https://essentials.com/" />
-    <link rel="alternate" hreflang="en-GB" href="https://essentials.co.uk/" />
-    <link rel="alternate" hreflang="en-GB" href="https://essentials.uk/" />
-    <link rel="alternate" hreflang="en" href="https://essentials.net/" />
-    <link rel="alternate" hreflang="de" href="https://essentials.eu/" />
-    <link rel="alternate" hreflang="en-US" href="https://essentials.us/" />
-    <link rel="alternate" hreflang="fr" href="https://essentials.fr/" />
-    <link rel="alternate" hreflang="zh-CN" href="https://essentials.cn/" />
-    <link rel="alternate" hreflang="zh-HK" href="https://essentials.hk/" />
-    <link rel="alternate" hreflang="zh-TW" href="https://essentials.tw/" />
-    <link rel="alternate" hreflang="en" href="https://essentials.mobi/" />
-    <link rel="alternate" hreflang="x-default" href="https://essentials.com/" />
+    <link rel="canonical" href="https://www.essentials.com/">
+    <link rel="alternate" hreflang="en" href="https://www.essentials.com/" />
+    <link rel="alternate" hreflang="en-GB" href="https://www.essentials.co.uk/" />
+    <link rel="alternate" hreflang="en-GB" href="https://www.essentials.uk/" />
+    <link rel="alternate" hreflang="en" href="https://www.essentials.net/" />
+    <link rel="alternate" hreflang="de" href="https://www.essentials.eu/" />
+    <link rel="alternate" hreflang="en-US" href="https://www.essentials.us/" />
+    <link rel="alternate" hreflang="fr" href="https://www.essentials.fr/" />
+    <link rel="alternate" hreflang="zh-CN" href="https://www.essentials.com/" />
+    <link rel="alternate" hreflang="zh-HK" href="https://www.essentials.hk/" />
+    <link rel="alternate" hreflang="zh-TW" href="https://www.essentials.tw/" />
+    <link rel="alternate" hreflang="en" href="https://www.essentials.mobi/" />
+    <link rel="alternate" hreflang="x-default" href="https://www.essentials.com/" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
@@ -35,28 +35,28 @@
     <meta property="og:title" content="ESSENTIALS.COM">
     <meta property="og:description" content="essentials.com, .net, .co.uk, .uk, .eu, .us, .fr, .cn, .hk, .tw, .mobi - Premium brand rare one-word global domain collection for sale.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://essentials.com/">
+    <meta property="og:url" content="https://www.essentials.com/">
     <meta property="og:site_name" content="Essentials">
     <meta property="og:locale" content="en_US">
-    <meta property="og:image" content="https://essentials.com/android-chrome-512x512.png">
+    <meta property="og:image" content="https://www.essentials.com/android-chrome-512x512.png">
     <meta property="og:image:width" content="512">
     <meta property="og:image:height" content="512">
     <meta property="og:image:alt" content="Essentials logo">
     <meta name="twitter:card" content="summary">
     <meta name="twitter:title" content="ESSENTIALS.COM">
     <meta name="twitter:description" content="Premium domain portfolio featuring essentials.com and international TLDs. A rare collection of one-word domains for a trusted global brand.">
-    <meta name="twitter:image" content="https://essentials.com/android-chrome-512x512.png">
+    <meta name="twitter:image" content="https://www.essentials.com/android-chrome-512x512.png">
     <meta name="twitter:image:alt" content="Essentials logo">
     <script type="application/ld+json">
     {
         "@context": "https://schema.org",
         "@type": "WebSite",
         "name": "Essentials",
-        "url": "https://essentials.com/",
+        "url": "https://www.essentials.com/",
         "description": "essentials.com, .net, .co.uk, .uk, .eu, .us, .fr, .cn, .hk, .tw, .mobi - Premium brand rare one-word global domain collection for sale.",
         "potentialAction": {
             "@type": "SearchAction",
-            "target": "https://essentials.com/?q={search_term_string}",
+            "target": "https://www.essentials.com/?q={search_term_string}",
             "query-input": "required name=search_term_string"
         }
     }
@@ -87,8 +87,8 @@
         "@context": "https://schema.org",
         "@type": "Organization",
         "name": "Essentials",
-        "url": "https://essentials.com/",
-        "logo": "https://essentials.com/android-chrome-512x512.png",
+        "url": "https://www.essentials.com/",
+        "logo": "https://www.essentials.com/android-chrome-512x512.png",
         "sameAs": []
     }
     </script>
@@ -1234,17 +1234,17 @@
 
     <script>
         const allDomains = [
-            { name: 'ESSENTIALS.COM', url: 'https://www.essentials.com/', canonical: 'https://essentials.com/', hreflang: 'en' },
-            { name: 'ESSENTIALS.CO.UK', url: 'https://www.essentials.co.uk/', canonical: 'https://essentials.co.uk/', hreflang: 'en-GB' },
-            { name: 'ESSENTIALS.UK', url: 'https://www.essentials.uk/', canonical: 'https://essentials.uk/', hreflang: 'en-GB' },
-            { name: 'ESSENTIALS.NET', url: 'https://www.essentials.net/', canonical: 'https://essentials.net/', hreflang: 'en' },
-            { name: 'ESSENTIALS.EU', url: 'https://www.essentials.eu/', canonical: 'https://essentials.eu/', hreflang: 'de' },
-            { name: 'ESSENTIALS.US', url: 'https://www.essentials.us/', canonical: 'https://essentials.us/', hreflang: 'en-US' },
-            { name: 'ESSENTIALS.FR', url: 'https://www.essentials.fr/', canonical: 'https://essentials.fr/', hreflang: 'fr' },
-            { name: 'ESSENTIALS.CN', url: 'https://www.essentials.com/', canonical: 'https://essentials.cn/', hreflang: 'zh-CN' },
-            { name: 'ESSENTIALS.HK', url: 'https://www.essentials.hk/', canonical: 'https://essentials.hk/', hreflang: 'zh-HK' },
-            { name: 'ESSENTIALS.TW', url: 'https://www.essentials.tw/', canonical: 'https://essentials.tw/', hreflang: 'zh-TW' },
-            { name: 'ESSENTIALS.MOBI', url: 'https://www.essentials.mobi/', canonical: 'https://essentials.mobi/', hreflang: 'en' }
+            { name: 'ESSENTIALS.COM', url: 'https://www.essentials.com/', canonical: 'https://www.essentials.com/', hreflang: 'en' },
+            { name: 'ESSENTIALS.CO.UK', url: 'https://www.essentials.co.uk/', canonical: 'https://www.essentials.co.uk/', hreflang: 'en-GB' },
+            { name: 'ESSENTIALS.UK', url: 'https://www.essentials.uk/', canonical: 'https://www.essentials.uk/', hreflang: 'en-GB' },
+            { name: 'ESSENTIALS.NET', url: 'https://www.essentials.net/', canonical: 'https://www.essentials.net/', hreflang: 'en' },
+            { name: 'ESSENTIALS.EU', url: 'https://www.essentials.eu/', canonical: 'https://www.essentials.eu/', hreflang: 'de' },
+            { name: 'ESSENTIALS.US', url: 'https://www.essentials.us/', canonical: 'https://www.essentials.us/', hreflang: 'en-US' },
+            { name: 'ESSENTIALS.FR', url: 'https://www.essentials.fr/', canonical: 'https://www.essentials.fr/', hreflang: 'fr' },
+            { name: 'ESSENTIALS.CN', url: 'https://www.essentials.com/', canonical: 'https://www.essentials.com/', hreflang: 'zh-CN' },
+            { name: 'ESSENTIALS.HK', url: 'https://www.essentials.hk/', canonical: 'https://www.essentials.hk/', hreflang: 'zh-HK' },
+            { name: 'ESSENTIALS.TW', url: 'https://www.essentials.tw/', canonical: 'https://www.essentials.tw/', hreflang: 'zh-TW' },
+            { name: 'ESSENTIALS.MOBI', url: 'https://www.essentials.mobi/', canonical: 'https://www.essentials.mobi/', hreflang: 'en' }
         ];
 
         const isLocal = ['localhost', '127.0.0.1', ''].includes(window.location.hostname) || 


### PR DESCRIPTION
## Summary

- Update all canonical URLs from non-www to www to match actual served URLs
- Fix essentials.cn canonical to point to www.essentials.com (DNS unavailable for .cn)
- Update hreflang alternates to use www versions consistently

## Changes

| Location | Before | After |
|----------|--------|-------|
| Static canonical | `https://essentials.com/` | `https://www.essentials.com/` |
| JS domain data | `canonical: 'https://essentials.com/'` | `canonical: 'https://www.essentials.com/'` |
| essentials.cn | `canonical: 'https://essentials.cn/'` | `canonical: 'https://www.essentials.com/'` |
| hreflang alternates | non-www | www |
| og:url, og:image | non-www | www |
| twitter:image | non-www | www |
| Structured data URLs | non-www | www |

## Why

Since the site redirects non-www to www via Cloudflare, canonicals should point to the actual URL users land on. This ensures search engines see consistent URLs and prevents potential duplicate content issues.

For essentials.cn specifically, DNS is unavailable so it redirects to essentials.com - the canonical now reflects this reality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Updated SEO metadata tags including canonical, OpenGraph, and Twitter tags to consistently reference www-prefixed domains across the site.
* Standardized domain mappings, navigation rendering, and domain-resolution logic to use www variants throughout.
* Aligned CTA links, domain-switching navigation, and logo rendering with the updated www domain URLs for complete consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->