### PR TITLE
fix: enable compression by removing no-transform from Cache-Control

### DIFF
--- a/workers/essentials-proxy.js
+++ b/workers/essentials-proxy.js
@@ -107,9 +107,9 @@ Sitemap: https://${wwwHost}/sitemap.xml`;
     // Add a header so the JavaScript can detect the original domain
     newHeaders.set("X-Original-Host", originalHost);
     
-    // Set no-transform to prevent Cloudflare from auto-injecting the beacon
-    // This allows us to inject the correct beacon for each domain
-    newHeaders.set("Cache-Control", "public, no-transform");
+    // Allow Cloudflare to compress the response (gzip/brotli)
+    // HTMLRewriter handles beacon injection, so no-transform is not needed
+    newHeaders.set("Cache-Control", "public");
     
     // Check if this is HTML content that needs beacon injection
     const contentType = response.headers.get("content-type") || "";


### PR DESCRIPTION
## Summary

Enables gzip/brotli compression by removing `no-transform` from the proxy worker's Cache-Control header.

## Problem

Ahrefs flagged "Not compressed" - the site was serving 86KB uncompressed HTML because `no-transform` tells Cloudflare not to modify the response (including compression).

## Solution

Change `Cache-Control: public, no-transform` to `Cache-Control: public`.

The `no-transform` was originally added to prevent Cloudflare from auto-injecting analytics beacons, but this is unnecessary because:
1. HTMLRewriter already removes any auto-injected beacons
2. HTMLRewriter injects the correct per-domain beacon

## Expected Result

After deploying the worker update:
- Response will include `Content-Encoding: br` or `gzip`
- ~86KB → ~15-20KB compressed
- Faster page loads
- Ahrefs "Not compressed" issue resolved

## Deployment

After merge, deploy the worker:
```bash
cd workers && wrangler deploy -c wrangler-proxy.toml
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated response caching configuration to enable more efficient compression.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->