### PR TITLE
fix: remove stack trace exposure from stats worker error response

### DIFF
--- a/workers/essentials-stats.js
+++ b/workers/essentials-stats.js
@@ -12,7 +12,7 @@ export default {
           headers: { "Content-Type": "application/json" }
         });
       } catch (e) {
-        return new Response(JSON.stringify({ error: e.message, stack: e.stack }), { 
+        return new Response(JSON.stringify({ error: "Internal server error" }), { 
           status: 500,
           headers: { "Content-Type": "application/json" }
         });


### PR DESCRIPTION
## Summary

- Removes `stack: e.stack` and `error: e.message` from the catch block JSON response in `workers/essentials-stats.js`
- Returns a generic `"Internal server error"` message instead, preventing implementation details from leaking to clients in production

Closes #13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error responses now return a generic message instead of exposing detailed error information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->