### PR TITLE
refactor: consolidate duplicated domain lists into shared configuration

### DIFF
--- a/index.html
+++ b/index.html
@@ -1232,20 +1232,10 @@
         </div>
     </footer>
 
-    <script>
-        const allDomains = [
-            { name: 'ESSENTIALS.COM', url: 'https://www.essentials.com/', canonical: 'https://www.essentials.com/', hreflang: 'en' },
-            { name: 'ESSENTIALS.CO.UK', url: 'https://www.essentials.co.uk/', canonical: 'https://www.essentials.co.uk/', hreflang: 'en-GB' },
-            { name: 'ESSENTIALS.UK', url: 'https://www.essentials.uk/', canonical: 'https://www.essentials.uk/', hreflang: 'en' },
-            { name: 'ESSENTIALS.NET', url: 'https://www.essentials.net/', canonical: 'https://www.essentials.net/', hreflang: 'en' },
-            { name: 'ESSENTIALS.EU', url: 'https://www.essentials.eu/', canonical: 'https://www.essentials.eu/', hreflang: 'de' },
-            { name: 'ESSENTIALS.US', url: 'https://www.essentials.us/', canonical: 'https://www.essentials.us/', hreflang: 'en-US' },
-            { name: 'ESSENTIALS.FR', url: 'https://www.essentials.fr/', canonical: 'https://www.essentials.fr/', hreflang: 'fr' },
-            { name: 'ESSENTIALS.CN', url: 'https://www.essentials.com/', canonical: 'https://www.essentials.com/', hreflang: 'zh-CN' },
-            { name: 'ESSENTIALS.HK', url: 'https://www.essentials.hk/', canonical: 'https://www.essentials.hk/', hreflang: 'zh-HK' },
-            { name: 'ESSENTIALS.TW', url: 'https://www.essentials.tw/', canonical: 'https://www.essentials.tw/', hreflang: 'zh-TW' },
-            { name: 'ESSENTIALS.MOBI', url: 'https://www.essentials.mobi/', canonical: 'https://www.essentials.mobi/', hreflang: 'en' }
-        ];
+    <script type="module">
+        // Domain config imported from shared single source of truth (workers/domains.js)
+        import { getAllDomains, getSkipDomains, getDomainList } from './workers/domains.js';
+        const allDomains = getAllDomains();
 
         const isLocal = ['localhost', '127.0.0.1', ''].includes(window.location.hostname) || 
                         window.location.protocol === 'file:';
@@ -1443,19 +1433,7 @@
             
             // Generate colors based on current dot-color with brightness variations
             function getDomainColors() {
-                const domains = [
-                    'essentials.com',
-                    'essentials.net', 
-                    'essentials.co.uk',
-                    'essentials.uk',
-                    'essentials.eu',
-                    'essentials.us',
-                    'essentials.fr',
-                    'essentials.cn',
-                    'essentials.hk',
-                    'essentials.tw',
-                    'essentials.mobi'
-                ];
+                const domains = getDomainList();
                 
                 const isDark = root.getAttribute('data-theme') === 'dark' || 
                     (!root.getAttribute('data-theme') && window.matchMedia('(prefers-color-scheme: dark)').matches);
@@ -1959,8 +1937,8 @@
                 return dotIndex !== -1 && targetIndex > dotIndex;
             }
 
-            // Domains to skip in rotation (DNS not available)
-            const skipDomains = ['ESSENTIALS.CN'];
+            // Domains to skip in rotation (DNS not available) — derived from shared config
+            const skipDomains = getSkipDomains();
             
             function navigateToNextDomain() {
                 const currentDomain = getCurrentDomain();

--- a/workers/domains.js
+++ b/workers/domains.js
@@ -1,0 +1,104 @@
+/**
+ * Shared domain configuration — single source of truth.
+ *
+ * All domain lists, zone IDs, analytics tokens, and hreflang mappings live here.
+ * Consumed by:
+ *   - workers/essentials-proxy.js  (validHosts, siteTokens)
+ *   - workers/essentials-stats.js  (zones)
+ *   - index.html                   (allDomains for UI rendering)
+ *
+ * To add or remove a domain, edit the DOMAINS array below.
+ * Everything else is derived automatically.
+ */
+
+/**
+ * @typedef {Object} DomainEntry
+ * @property {string} tld        - The bare domain (e.g. "essentials.com")
+ * @property {string} zoneId     - Cloudflare Zone ID for Zone Analytics
+ * @property {string} siteToken  - Cloudflare Web Analytics beacon token
+ * @property {string} hreflang   - hreflang code for SEO
+ * @property {boolean} [dnsUnavailable] - true if DNS is not active (e.g. essentials.cn)
+ */
+
+/** @type {DomainEntry[]} */
+export const DOMAINS = [
+  { tld: "essentials.com",   zoneId: "3962b136d6e3492bdb570478899847b2", siteToken: "9c7ff93ede994719be16a87fdbbdb6d0", hreflang: "en" },
+  { tld: "essentials.co.uk", zoneId: "f5df3dc2776423f4653d4f58f7bf819c", siteToken: "bd2ac6db233d4b7a80528a70e8765961", hreflang: "en-GB" },
+  { tld: "essentials.uk",    zoneId: "5dd34def9f2ad086dd54afef45abc7c5", siteToken: "dafd69ae431245e59bf2658de918385d", hreflang: "en" },
+  { tld: "essentials.net",   zoneId: "d2bb7fe3fdb1217b844ef3c61deaf7e0", siteToken: "af1f8e9509494fdc9296748bccfa4f67", hreflang: "en" },
+  { tld: "essentials.eu",    zoneId: "75a68625aff272cfcd14be528568774e", siteToken: "ea6290a203dd479eb29129f67a63a707", hreflang: "de" },
+  { tld: "essentials.us",    zoneId: "0030f0ca87bb371396df88f626f40f51", siteToken: "0cf65acf96c340bf97f088b639741fac", hreflang: "en-US" },
+  { tld: "essentials.fr",    zoneId: "51bd9812a67450597344caaba49dcf0c", siteToken: "2a2a52689b9846b2b982cf22cd060758", hreflang: "fr" },
+  { tld: "essentials.cn",    zoneId: "9c657d9a33c65cf08f7388bac27567fb", siteToken: "91fea634621d4b7a8603cabadaf4d669", hreflang: "zh-CN", dnsUnavailable: true },
+  { tld: "essentials.hk",    zoneId: "eba3476c1545e7921a74afd94910ef7a", siteToken: "81b6f31ee014450c92c7941f3d963d9b", hreflang: "zh-HK" },
+  { tld: "essentials.tw",    zoneId: "fa860897d24799154c196c1a3df49d68", siteToken: "ced9f723c52f4518928c063a63151baa", hreflang: "zh-TW" },
+  { tld: "essentials.mobi",  zoneId: "dc698847dff06bf68ff8356605228d82", siteToken: "141ccb0338744ec5aa52bc614d034937", hreflang: "en" },
+];
+
+/**
+ * Valid hosts for the proxy worker (root + www for each domain).
+ * @returns {string[]}
+ */
+export function getValidHosts() {
+  const hosts = [];
+  for (const d of DOMAINS) {
+    hosts.push(d.tld, `www.${d.tld}`);
+  }
+  return hosts;
+}
+
+/**
+ * Site token lookup keyed by hostname (root + www both map to the same token).
+ * @returns {Record<string, string>}
+ */
+export function getSiteTokens() {
+  const tokens = {};
+  for (const d of DOMAINS) {
+    tokens[d.tld] = d.siteToken;
+    tokens[`www.${d.tld}`] = d.siteToken;
+  }
+  return tokens;
+}
+
+/**
+ * Zone ID lookup keyed by bare domain.
+ * @returns {Record<string, string>}
+ */
+export function getZones() {
+  const zones = {};
+  for (const d of DOMAINS) {
+    zones[d.tld] = d.zoneId;
+  }
+  return zones;
+}
+
+/**
+ * Domain list for the front-end UI (name, url, canonical, hreflang).
+ * Domains with dnsUnavailable link to essentials.com instead.
+ * @returns {Array<{name: string, url: string, canonical: string, hreflang: string}>}
+ */
+export function getAllDomains() {
+  return DOMAINS.map(d => {
+    const name = d.tld.toUpperCase();
+    const fallbackUrl = "https://www.essentials.com/";
+    const url = d.dnsUnavailable ? fallbackUrl : `https://www.${d.tld}/`;
+    const canonical = d.dnsUnavailable ? fallbackUrl : `https://www.${d.tld}/`;
+    return { name, url, canonical, hreflang: d.hreflang };
+  });
+}
+
+/**
+ * Bare domain names that should be skipped in UI rotation (DNS unavailable).
+ * @returns {string[]}
+ */
+export function getSkipDomains() {
+  return DOMAINS.filter(d => d.dnsUnavailable).map(d => d.tld.toUpperCase());
+}
+
+/**
+ * Bare domain list (e.g. for chart colors, legend).
+ * @returns {string[]}
+ */
+export function getDomainList() {
+  return DOMAINS.map(d => d.tld);
+}

--- a/workers/essentials-proxy.js
+++ b/workers/essentials-proxy.js
@@ -1,3 +1,8 @@
+import { getValidHosts, getSiteTokens } from "./domains.js";
+
+const validHosts = getValidHosts();
+const siteTokens = getSiteTokens();
+
 // Security headers applied to all responses
 const securityHeaders = {
   "X-Frame-Options": "DENY",
@@ -28,21 +33,6 @@ export default {
   async fetch(request) {
     const url = new URL(request.url);
     const originalHost = url.host;
-    
-    // Valid hosts (root and www only)
-    const validHosts = [
-      "essentials.com", "www.essentials.com",
-      "essentials.net", "www.essentials.net",
-      "essentials.co.uk", "www.essentials.co.uk",
-      "essentials.uk", "www.essentials.uk",
-      "essentials.eu", "www.essentials.eu",
-      "essentials.us", "www.essentials.us",
-      "essentials.fr", "www.essentials.fr",
-      "essentials.cn", "www.essentials.cn",
-      "essentials.hk", "www.essentials.hk",
-      "essentials.tw", "www.essentials.tw",
-      "essentials.mobi", "www.essentials.mobi",
-    ];
     
     // 301 redirect unknown subdomains to www.essentials.com
     if (!validHosts.includes(originalHost)) {
@@ -82,33 +72,6 @@ Sitemap: https://${wwwHost}/sitemap.xml`;
         }),
       });
     }
-    
-    // Site tokens for each domain (Cloudflare Web Analytics beacon)
-    // Note: site_token is used in the beacon script, site_tag is used in GraphQL API queries
-    const siteTokens = {
-      "essentials.com": "9c7ff93ede994719be16a87fdbbdb6d0",
-      "www.essentials.com": "9c7ff93ede994719be16a87fdbbdb6d0",
-      "essentials.net": "af1f8e9509494fdc9296748bccfa4f67",
-      "www.essentials.net": "af1f8e9509494fdc9296748bccfa4f67",
-      "essentials.co.uk": "bd2ac6db233d4b7a80528a70e8765961",
-      "www.essentials.co.uk": "bd2ac6db233d4b7a80528a70e8765961",
-      "essentials.uk": "dafd69ae431245e59bf2658de918385d",
-      "www.essentials.uk": "dafd69ae431245e59bf2658de918385d",
-      "essentials.eu": "ea6290a203dd479eb29129f67a63a707",
-      "www.essentials.eu": "ea6290a203dd479eb29129f67a63a707",
-      "essentials.us": "0cf65acf96c340bf97f088b639741fac",
-      "www.essentials.us": "0cf65acf96c340bf97f088b639741fac",
-      "essentials.fr": "2a2a52689b9846b2b982cf22cd060758",
-      "www.essentials.fr": "2a2a52689b9846b2b982cf22cd060758",
-      "essentials.cn": "91fea634621d4b7a8603cabadaf4d669",
-      "www.essentials.cn": "91fea634621d4b7a8603cabadaf4d669",
-      "essentials.hk": "81b6f31ee014450c92c7941f3d963d9b",
-      "www.essentials.hk": "81b6f31ee014450c92c7941f3d963d9b",
-      "essentials.tw": "ced9f723c52f4518928c063a63151baa",
-      "www.essentials.tw": "ced9f723c52f4518928c063a63151baa",
-      "essentials.mobi": "141ccb0338744ec5aa52bc614d034937",
-      "www.essentials.mobi": "141ccb0338744ec5aa52bc614d034937",
-    };
     
     // Get the correct site token for this domain
     const siteToken = siteTokens[originalHost] || siteTokens["essentials.com"];

--- a/workers/essentials-stats.js
+++ b/workers/essentials-stats.js
@@ -1,3 +1,5 @@
+import { getZones } from "./domains.js";
+
 export default {
   async scheduled(event, env, ctx) {
     await updateStats(env);
@@ -23,21 +25,9 @@ export default {
 };
 
 async function updateStats(env) {
-  // Zone IDs for Zone Analytics (httpRequests1dGroups)
+  // Zone IDs from shared config (used for Zone Analytics httpRequests1dGroups)
   // Note: Using uniq.uniques for unique visitor counts (filters out bots)
-  const zones = {
-    "essentials.com": "3962b136d6e3492bdb570478899847b2",
-    "essentials.net": "d2bb7fe3fdb1217b844ef3c61deaf7e0",
-    "essentials.co.uk": "f5df3dc2776423f4653d4f58f7bf819c",
-    "essentials.uk": "5dd34def9f2ad086dd54afef45abc7c5",
-    "essentials.eu": "75a68625aff272cfcd14be528568774e",
-    "essentials.us": "0030f0ca87bb371396df88f626f40f51",
-    "essentials.fr": "51bd9812a67450597344caaba49dcf0c",
-    "essentials.cn": "9c657d9a33c65cf08f7388bac27567fb",
-    "essentials.hk": "eba3476c1545e7921a74afd94910ef7a",
-    "essentials.tw": "fa860897d24799154c196c1a3df49d68",
-    "essentials.mobi": "dc698847dff06bf68ff8356605228d82"
-  };
+  const zones = getZones();
 
   const endDate = new Date();
   const startDate = new Date();


### PR DESCRIPTION
## Summary

- Creates `workers/domains.js` as the single source of truth for all domain configuration (TLDs, Cloudflare Zone IDs, Web Analytics tokens, hreflang mappings, DNS availability flags)
- Updates `workers/essentials-proxy.js` to import `getValidHosts()` and `getSiteTokens()` from the shared config instead of hardcoding 22+22 entries
- Updates `workers/essentials-stats.js` to import `getZones()` from the shared config instead of hardcoding 11 zone ID entries
- Updates `index.html` to import `getAllDomains()`, `getSkipDomains()`, and `getDomainList()` from the shared config via ES module import, eliminating 3 separate hardcoded domain lists

Adding or removing a domain now requires editing one file (`workers/domains.js`) instead of 4.

Net reduction: 62 lines of duplicated configuration code removed.

Closes #14