### PR TITLE
docs: replace duplicated domain tables in AGENTS.md with reference to domains.js

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,8 @@ Domain collection landing page for the essentials.* portfolio, hosted on GitHub 
 
 ## Domains
 
-All domains serve the same content; JavaScript detects the hostname and updates the display:
+All domains serve the same content; JavaScript detects the hostname and updates the display.
+To add or remove a domain, edit `workers/domains.js` — all other files import from it.
 
 - essentials.com (primary)
 - essentials.net
@@ -35,10 +36,11 @@ All domains serve the same content; JavaScript detects the hostname and updates 
 | File | Purpose |
 |------|---------|
 | `index.html` | Single-page site with all HTML, CSS, and JavaScript |
+| `workers/domains.js` | **Single source of truth** for all domain config (TLDs, Zone IDs, analytics tokens, hreflang) |
 | `stats.json` | Visitor statistics on `stats` branch, auto-updated by Cloudflare Worker |
 | `CNAME` | GitHub Pages custom domain (www.essentials.com) |
-| `workers/essentials-proxy.js` | Proxy worker source code |
-| `workers/essentials-stats.js` | Stats worker source code |
+| `workers/essentials-proxy.js` | Proxy worker source code (imports from `domains.js`) |
+| `workers/essentials-stats.js` | Stats worker source code (imports from `domains.js`) |
 | `workers/wrangler-*.toml` | Wrangler deployment configs |
 | `workers/README.md` | Worker setup and deployment guide |
 
@@ -49,45 +51,12 @@ All domains serve the same content; JavaScript detects the hostname and updates 
 - CNAME records point to `essentials-com.github.io` with proxy enabled (orange cloud)
 
 ### Workers
-- **essentials-proxy**: Routes all domain aliases to fetch content from www.essentials.com. Uses `HTMLRewriter` to inject the correct Web Analytics beacon for each domain. Sets `Cache-Control: no-transform` to prevent Cloudflare auto-injecting the wrong beacon.
-- **essentials-stats**: Cron-triggered (every 5 mins), queries Zone Analytics (`httpRequests1dGroups`) for all 11 domains, commits stats.json to GitHub
+- **essentials-proxy**: Routes all domain aliases to fetch content from www.essentials.com. Uses `HTMLRewriter` to inject the correct Web Analytics beacon for each domain (tokens from `workers/domains.js`).
+- **essentials-stats**: Cron-triggered (every 5 mins), queries Zone Analytics (`httpRequests1dGroups`) for all 11 domains (zone IDs from `workers/domains.js`), commits stats.json to GitHub
 
-### Zone IDs
+### Zone IDs & Web Analytics Tokens
 
-Zone IDs are used by the stats worker to query Zone Analytics via GraphQL API:
-
-| Domain | Zone ID |
-|--------|---------|
-| essentials.com | `3962b136d6e3492bdb570478899847b2` |
-| essentials.net | `d2bb7fe3fdb1217b844ef3c61deaf7e0` |
-| essentials.co.uk | `f5df3dc2776423f4653d4f58f7bf819c` |
-| essentials.uk | `5dd34def9f2ad086dd54afef45abc7c5` |
-| essentials.eu | `75a68625aff272cfcd14be528568774e` |
-| essentials.us | `0030f0ca87bb371396df88f626f40f51` |
-| essentials.fr | `51bd9812a67450597344caaba49dcf0c` |
-| essentials.cn | `9c657d9a33c65cf08f7388bac27567fb` |
-| essentials.hk | `eba3476c1545e7921a74afd94910ef7a` |
-| essentials.tw | `fa860897d24799154c196c1a3df49d68` |
-| essentials.mobi | `dc698847dff06bf68ff8356605228d82` |
-
-### Web Analytics Tokens
-
-Cloudflare Web Analytics tokens are used by the proxy worker to inject per-domain beacons:
-- **Site Token**: Used in the beacon script injected into HTML (used by `essentials-proxy` worker)
-
-| Domain | Site Token (Beacon) |
-|--------|---------------------|
-| essentials.com | `9c7ff93ede994719be16a87fdbbdb6d0` |
-| essentials.net | `af1f8e9509494fdc9296748bccfa4f67` |
-| essentials.co.uk | `bd2ac6db233d4b7a80528a70e8765961` |
-| essentials.uk | `dafd69ae431245e59bf2658de918385d` |
-| essentials.eu | `ea6290a203dd479eb29129f67a63a707` |
-| essentials.us | `0cf65acf96c340bf97f088b639741fac` |
-| essentials.fr | `2a2a52689b9846b2b982cf22cd060758` |
-| essentials.cn | `91fea634621d4b7a8603cabadaf4d669` |
-| essentials.hk | `81b6f31ee014450c92c7941f3d963d9b` |
-| essentials.tw | `ced9f723c52f4518928c063a63151baa` |
-| essentials.mobi | `141ccb0338744ec5aa52bc614d034937` |
+All per-domain Cloudflare Zone IDs and Web Analytics site tokens are defined in `workers/domains.js` (the `DOMAINS` array). Each entry contains `zoneId` and `siteToken` fields. These are public identifiers, not secrets.
 
 ### Analytics
 - Stats use Zone Analytics (`httpRequests1dGroups`) with `uniq.uniques` for unique visitor counts


### PR DESCRIPTION
## Summary

- Removes hardcoded Zone ID table (11 entries) and Web Analytics Token table (11 entries) from AGENTS.md — these duplicated `workers/domains.js`
- Adds `workers/domains.js` to the Key Files table as the **single source of truth** for all domain configuration
- Adds note in Domains section directing editors to `workers/domains.js` for adding/removing domains
- Fixes stale `Cache-Control: no-transform` reference in Workers description (removed in PR #3)

Completes the documentation side of the domain config consolidation started in PR #16. Adding or removing a domain now requires editing one file instead of four.

Closes #17

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Consolidated domain configuration documentation to clarify centralized management of domain settings.
  * Updated instructions for adding or removing domains and managing domain-specific identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->