### PR TITLE
t024: add server-side error logging to stats worker catch blocks

### DIFF
--- a/workers/essentials-stats.js
+++ b/workers/essentials-stats.js
@@ -14,6 +14,7 @@ export default {
           headers: { "Content-Type": "application/json" }
         });
       } catch (e) {
+        console.error("Stats update failed:", e);
         return new Response(JSON.stringify({ error: "Internal server error" }), { 
           status: 500,
           headers: { "Content-Type": "application/json" }
@@ -123,7 +124,8 @@ async function updateStats(env) {
         });
       }
     } catch (e) {
-      errors.push({ domain, error: e.message });
+      console.error(`Failed to fetch stats for ${domain}:`, e);
+      errors.push({ domain, error: "Failed to fetch domain data" });
     }
   }
 
@@ -160,7 +162,9 @@ async function updateStats(env) {
       const fileData = await getFile.json();
       sha = fileData.sha;
     }
-  } catch (e) {}
+  } catch (e) {
+    console.error("Failed to fetch existing stats.json SHA:", e);
+  }
 
   const commitBody = {
     message: `Update stats ${formatDate(endDate)}`,


### PR DESCRIPTION
## Summary

- Add `console.error()` before generic 500 response in `fetch()` catch block (HIGH - Gemini review)
- Add `console.error()` to previously empty catch block when fetching existing `stats.json` SHA
- Sanitize per-domain error messages: return `"Failed to fetch domain data"` instead of raw `e.message` to prevent leaking implementation details (CodeRabbit nitpick)

All errors are now logged server-side (visible in Cloudflare Worker logs) while keeping client responses generic.

Closes #24

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error logging and handling across multiple data retrieval processes for better visibility into failures.
  * Enhanced error messages to provide more consistent and user-friendly feedback when data operations encounter issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->