### PR TITLE
t025: replace unsafe-inline CSP with per-request nonces

### DIFF
--- a/workers/essentials-proxy.js
+++ b/workers/essentials-proxy.js
@@ -3,28 +3,59 @@ import { getValidHosts, getSiteTokens } from "./domains.js";
 const validHosts = getValidHosts();
 const siteTokens = getSiteTokens();
 
-// Security headers applied to all responses
+// Static security headers applied to all responses
 const securityHeaders = {
   "X-Frame-Options": "DENY",
   "X-Content-Type-Options": "nosniff",
   "Referrer-Policy": "strict-origin-when-cross-origin",
   "Permissions-Policy": "camera=(), microphone=(), geolocation=(), payment=()",
-  "Content-Security-Policy":
-    "default-src 'self'; " +
-    "script-src 'self' 'unsafe-inline' https://analytics.ahrefs.com https://static.cloudflareinsights.com; " +
-    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; " +
-    "font-src 'self' https://fonts.gstatic.com https://fonts.googleapis.com; " +
-    "img-src 'self' data:; " +
-    "connect-src 'self' https://raw.githubusercontent.com https://analytics.ahrefs.com https://cloudflareinsights.com; " +
-    "frame-src 'none'; " +
-    "object-src 'none'; " +
-    "base-uri 'self'; " +
-    "form-action 'self'",
 };
 
-function applySecurityHeaders(headers) {
-  for (const [key, value] of Object.entries(securityHeaders)) {
-    headers[key] = value;
+// CSP directives shared across all responses
+const cspBase = [
+  "default-src 'self'",
+  "font-src 'self' https://fonts.gstatic.com https://fonts.googleapis.com",
+  "img-src 'self' data:",
+  "connect-src 'self' https://raw.githubusercontent.com https://analytics.ahrefs.com https://cloudflareinsights.com",
+  "frame-src 'none'",
+  "object-src 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+];
+
+/**
+ * Build a Content-Security-Policy header value.
+ * When a nonce is provided (HTML responses), inline scripts and styles are
+ * allowed only if they carry the matching nonce attribute — 'unsafe-inline'
+ * is omitted entirely. For non-HTML responses (assets, sitemap, robots.txt)
+ * no nonce is needed and a restrictive static policy is used.
+ */
+function buildCsp(nonce) {
+  const scriptSrc = nonce
+    ? `script-src 'self' 'nonce-${nonce}' https://analytics.ahrefs.com https://static.cloudflareinsights.com`
+    : "script-src 'self' https://analytics.ahrefs.com https://static.cloudflareinsights.com";
+  const styleSrc = nonce
+    ? `style-src 'self' 'nonce-${nonce}' https://fonts.googleapis.com`
+    : "style-src 'self' https://fonts.googleapis.com";
+
+  return [...cspBase, scriptSrc, styleSrc].join("; ");
+}
+
+/**
+ * Apply security headers to either a plain object or a Headers instance.
+ * Accepts an optional nonce to build a per-request CSP.
+ * Returns the same headers reference for chaining.
+ */
+function applySecurityHeaders(headers, nonce) {
+  const csp = buildCsp(nonce);
+  const allHeaders = { ...securityHeaders, "Content-Security-Policy": csp };
+
+  for (const [key, value] of Object.entries(allHeaders)) {
+    if (headers instanceof Headers) {
+      headers.set(key, value);
+    } else {
+      headers[key] = value;
+    }
   }
   return headers;
 }
@@ -33,12 +64,12 @@ export default {
   async fetch(request) {
     const url = new URL(request.url);
     const originalHost = url.host;
-    
+
     // 301 redirect unknown subdomains to www.essentials.com
     if (!validHosts.includes(originalHost)) {
       return Response.redirect("https://www.essentials.com/", 301);
     }
-    
+
     // Generate dynamic sitemap.xml for the current domain
     if (url.pathname === "/sitemap.xml") {
       const wwwHost = originalHost.startsWith("www.") ? originalHost : `www.${originalHost}`;
@@ -57,7 +88,7 @@ export default {
         }),
       });
     }
-    
+
     // Generate dynamic robots.txt for the current domain
     if (url.pathname === "/robots.txt") {
       const wwwHost = originalHost.startsWith("www.") ? originalHost : `www.${originalHost}`;
@@ -72,13 +103,13 @@ Sitemap: https://${wwwHost}/sitemap.xml`;
         }),
       });
     }
-    
+
     // Get the correct site token for this domain
     const siteToken = siteTokens[originalHost] || siteTokens["essentials.com"];
-    
+
     // Fetch from www.essentials.com
     const targetUrl = `https://www.essentials.com${url.pathname}${url.search}`;
-    
+
     const response = await fetch(targetUrl, {
       method: request.method,
       headers: {
@@ -91,24 +122,25 @@ Sitemap: https://${wwwHost}/sitemap.xml`;
 
     // Clone the response and modify headers
     const newHeaders = new Headers(response.headers);
-    
+
     // Add a header so the JavaScript can detect the original domain
     newHeaders.set("X-Original-Host", originalHost);
-    
+
     // Prevent intermediate proxies from modifying the response body
     // (protects HTMLRewriter beacon injection from Cloudflare edge transforms)
     newHeaders.set("Cache-Control", "public, no-transform");
-    
-    // Security headers
-    for (const [key, value] of Object.entries(securityHeaders)) {
-      newHeaders.set(key, value);
-    }
-    
-    // Check if this is HTML content that needs beacon injection
+
+    // Check if this is HTML content that needs beacon injection + nonces
     const contentType = response.headers.get("content-type") || "";
     const isHtml = contentType.includes("text/html");
-    
-    // If not HTML, return as-is
+
+    // Generate a unique nonce for HTML responses (used in CSP + HTMLRewriter)
+    const nonce = isHtml ? crypto.randomUUID() : undefined;
+
+    // Apply security headers (CSP includes nonce only for HTML responses)
+    applySecurityHeaders(newHeaders, nonce);
+
+    // If not HTML, return as-is (no nonce, no rewriting)
     if (!isHtml) {
       return new Response(response.body, {
         status: response.status,
@@ -116,7 +148,7 @@ Sitemap: https://${wwwHost}/sitemap.xml`;
         headers: newHeaders,
       });
     }
-    
+
     // Create the Cloudflare Web Analytics beacon script for this domain
     // The beacon config must include:
     // - "version": Required for proper RUM endpoint routing (versions.fl in payload)
@@ -127,18 +159,35 @@ Sitemap: https://${wwwHost}/sitemap.xml`;
       version: "2024.11.0",
       token: siteToken,
       r: 1,
-      send: { to: "https://cloudflareinsights.com/cdn-cgi/rum" }
+      send: { to: "https://cloudflareinsights.com/cdn-cgi/rum" },
     };
-    const beaconScript = `<script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='${JSON.stringify(beaconConfig)}'></script>`;
-    
+    const beaconScript = `<script nonce="${nonce}" defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='${JSON.stringify(beaconConfig)}'></script>`;
+
     // Use HTMLRewriter to:
     // 1. Remove any existing Cloudflare beacon scripts (auto-injected by Cloudflare for essentials.com)
-    // 2. Inject the correct beacon for this domain
+    // 2. Add nonce attributes to all inline <script> and <style> elements (CSP compliance)
+    // 3. Inject the correct beacon for this domain (with nonce)
     const rewriter = new HTMLRewriter()
       .on("script[src*='cloudflareinsights.com/beacon']", {
         element(element) {
           // Remove auto-injected beacon scripts
           element.remove();
+        },
+      })
+      .on("script:not([src*='cloudflareinsights.com/beacon'])", {
+        element(element) {
+          // Add nonce to all other script elements (inline JS, JSON-LD, modules)
+          if (!element.getAttribute("nonce")) {
+            element.setAttribute("nonce", nonce);
+          }
+        },
+      })
+      .on("style", {
+        element(element) {
+          // Add nonce to all inline style elements
+          if (!element.getAttribute("nonce")) {
+            element.setAttribute("nonce", nonce);
+          }
         },
       })
       .on("body", {
@@ -147,7 +196,7 @@ Sitemap: https://${wwwHost}/sitemap.xml`;
           element.append(beaconScript, { html: true });
         },
       });
-    
+
     return rewriter.transform(
       new Response(response.body, {
         status: response.status,


### PR DESCRIPTION
## Summary

- **Eliminates `'unsafe-inline'` from CSP** by implementing per-request nonce-based script/style authorization via HTMLRewriter, significantly hardening XSS protection
- **Refactors CSP construction** from concatenated string to `buildCsp(nonce)` function using array.join() for readability
- **Unifies `applySecurityHeaders()`** to handle both plain objects and `Headers` instances, removing duplicate header application logic

## Review Findings Addressed

| # | Severity | Reviewer | Finding | Resolution |
|---|----------|----------|---------|------------|
| 1 | HIGH | Gemini | `'unsafe-inline'` in `script-src`/`style-src` weakens CSP | Replaced with `'nonce-...'` — unique nonce per request via `crypto.randomUUID()`, injected on all `<script>` and `<style>` elements by HTMLRewriter |
| 2 | HIGH | CodeRabbit | Missing `Cache-Control: no-transform` on proxied responses | Already present at line 131 — verified, no change needed |
| 3 | MEDIUM | Gemini | CSP string concatenation is hard to maintain | Refactored to `cspBase` array + `buildCsp()` function with `.join('; ')` |
| 4 | MEDIUM | Gemini | `applySecurityHeaders` mutates + has duplicate loop | Now supports both `Headers` and plain objects via `instanceof` check; single call site for all response types |

## How It Works

1. For HTML responses: `crypto.randomUUID()` generates a unique nonce
2. `buildCsp(nonce)` produces CSP with `'nonce-...'` instead of `'unsafe-inline'`
3. HTMLRewriter adds `nonce="..."` attribute to all `<script>` and `<style>` elements
4. The injected beacon script also carries the nonce
5. For non-HTML responses (assets, sitemap, robots.txt): no nonce, restrictive static CSP

## Post-merge action

Deploy the updated worker with `wrangler deploy` and purge Cloudflare cache for all domains.

Closes #25