### PR TITLE
fix: extract dot-color fallback values into named constants

### DIFF
--- a/index.html
+++ b/index.html
@@ -1838,10 +1838,6 @@
 
         // Random dot color on click
         (function() {
-            // Default dot colors matching CSS --dot-color per theme
-            const DOT_COLOR_DARK = '#FFD700';
-            const DOT_COLOR_LIGHT = '#DAA520';
-
             // Calculate relative luminance for contrast ratio
             function getLuminance(r, g, b) {
                 const [rs, gs, bs] = [r, g, b].map(c => {
@@ -1878,16 +1874,20 @@
                     }
                     attempts++;
                 }
-                // Fallback to default dot-color
-                return isDark ? DOT_COLOR_DARK : DOT_COLOR_LIGHT;
+                // Fallback: let CSS cascade apply the theme default
+                return null;
             }
 
             // Add click handler to logo dots
             document.getElementById('main-logo').addEventListener('click', (e) => {
                 if (e.target.classList.contains('dot')) {
                     const newColor = getRandomContrastColor();
-                    document.documentElement.style.setProperty('--dot-color', newColor);
-                    // Update chart colors to match
+                    if (newColor) {
+                        document.documentElement.style.setProperty('--dot-color', newColor);
+                    } else {
+                        // Revert to theme default from stylesheet
+                        document.documentElement.style.removeProperty('--dot-color');
+                    }
                     if (window.refreshChartColors) window.refreshChartColors();
                 }
             });


### PR DESCRIPTION
## Summary

- Remove hardcoded `DOT_COLOR_DARK` / `DOT_COLOR_LIGHT` constants that duplicated CSS `--dot-color` values
- Fallback now returns `null`; the click handler uses `removeProperty('--dot-color')` to let the CSS cascade apply the correct theme default
- CSS is the single source of truth for theme colors — zero duplication, zero drift risk

## Review Findings Addressed

| Severity | Reviewer | Finding | Resolution |
|----------|----------|---------|------------|
| High | Gemini (PR #31) | Hardcoded magic strings duplicate CSS `--dot-color` values | Eliminated entirely — fallback defers to CSS cascade |
| Medium | Gemini (PR #41) | Constants still duplicate CSS values | Removed constants; `null` fallback + `removeProperty` |

Closes #40

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Dot color now falls back to the active CSS theme by default, ensuring consistent light/dark appearance.
  * Clicking the logo applies a random dot color only when one is produced; otherwise the dot reverts to the stylesheet theme.

* **Bug Fixes**
  * Fixed fallback behavior so theme defaults are used instead of a hardcoded color.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->