### PR TITLE
perf: remove no-transform Cache-Control, preserve upstream directives

### DIFF
--- a/workers/essentials-proxy.js
+++ b/workers/essentials-proxy.js
@@ -134,10 +134,10 @@ Sitemap: https://${wwwHost}/sitemap.xml`;
     // data-cfasync="false" to opt out of Rocket Loader specifically.
     const upstreamCC = response.headers.get("Cache-Control") || "";
     const directives = upstreamCC.split(",").map((d) => d.trim()).filter(Boolean);
-    if (!directives.some((d) => d.startsWith("public") || d.startsWith("private"))) {
+    if (!directives.some((d) => /^(public|private)/i.test(d))) {
       directives.push("public");
     }
-    newHeaders.set("Cache-Control", directives.join(", ") || "public");
+    newHeaders.set("Cache-Control", directives.join(", "));
 
     // Check if this is HTML content that needs beacon injection + nonces
     const contentType = response.headers.get("content-type") || "";


### PR DESCRIPTION
## Summary

Fixes the performance regression and lost cache directives introduced by `Cache-Control: public, no-transform` in PR #32, as flagged by both Gemini and CodeRabbit reviewers.

### Changes

- **Remove `no-transform` from Cache-Control** — this directive disabled Cloudflare's Brotli/Gzip compression, serving uncompressed HTML to visitors. Instead, preserve upstream `Cache-Control` directives (e.g. `max-age=600` from GitHub Pages) and ensure `public` is present.

- **Add `data-cfasync="false"` to beacon script** — surgical opt-out from Cloudflare Rocket Loader (the only edge transform that could interfere with beacon injection), replacing the blunt `no-transform` approach that had compression as collateral damage.

### Verification (deployed and confirmed)

| Check | Before | After |
|-------|--------|-------|
| Cache-Control | `public, no-transform` | `max-age=600, public` |
| Content-Encoding | _(none — uncompressed)_ | `br` (Brotli) |
| Beacon protection | `no-transform` (disables all transforms) | `data-cfasync="false"` (Rocket Loader only) |

Closes #38

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced cache header handling to dynamically respect and preserve upstream Cache-Control directives while ensuring proper public visibility requirements across all responses
  * Optimized Cloudflare beacon script behavior for improved compatibility with browser-level script optimization features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->