### PR TITLE
fix: remove duplicate hreflang attributes for .net, .uk, .mobi

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,15 +13,12 @@
     <link rel="canonical" href="https://www.essentials.com/">
     <link rel="alternate" hreflang="en" href="https://www.essentials.com/" />
     <link rel="alternate" hreflang="en-GB" href="https://www.essentials.co.uk/" />
-    <link rel="alternate" hreflang="en" href="https://www.essentials.uk/" />
-    <link rel="alternate" hreflang="en" href="https://www.essentials.net/" />
     <link rel="alternate" hreflang="de" href="https://www.essentials.eu/" />
     <link rel="alternate" hreflang="en-US" href="https://www.essentials.us/" />
     <link rel="alternate" hreflang="fr" href="https://www.essentials.fr/" />
     <link rel="alternate" hreflang="zh-CN" href="https://www.essentials.com/" />
     <link rel="alternate" hreflang="zh-HK" href="https://www.essentials.hk/" />
     <link rel="alternate" hreflang="zh-TW" href="https://www.essentials.tw/" />
-    <link rel="alternate" hreflang="en" href="https://www.essentials.mobi/" />
     <link rel="alternate" hreflang="x-default" href="https://www.essentials.com/" />
     <link rel="icon" type="image/png" sizes="48x48" href="/favicon-48x48.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">

--- a/workers/domains.js
+++ b/workers/domains.js
@@ -16,7 +16,7 @@
  * @property {string} tld        - The bare domain (e.g. "essentials.com")
  * @property {string} zoneId     - Cloudflare Zone ID for Zone Analytics
  * @property {string} siteToken  - Cloudflare Web Analytics beacon token
- * @property {string} hreflang   - hreflang code for SEO
+ * @property {string|null} hreflang - hreflang code for SEO (null = no unique language-region; omit from hreflang tags)
  * @property {boolean} [dnsUnavailable] - true if DNS is not active (e.g. essentials.cn)
  */
 
@@ -33,15 +33,15 @@ const FALLBACK_URL = "https://www.essentials.com/";
 export const DOMAINS = [
   { tld: "essentials.com",   zoneId: "3962b136d6e3492bdb570478899847b2", siteToken: "9c7ff93ede994719be16a87fdbbdb6d0", hreflang: "en" },
   { tld: "essentials.co.uk", zoneId: "f5df3dc2776423f4653d4f58f7bf819c", siteToken: "bd2ac6db233d4b7a80528a70e8765961", hreflang: "en-GB" },
-  { tld: "essentials.uk",    zoneId: "5dd34def9f2ad086dd54afef45abc7c5", siteToken: "dafd69ae431245e59bf2658de918385d", hreflang: "en" },
-  { tld: "essentials.net",   zoneId: "d2bb7fe3fdb1217b844ef3c61deaf7e0", siteToken: "af1f8e9509494fdc9296748bccfa4f67", hreflang: "en" },
+  { tld: "essentials.uk",    zoneId: "5dd34def9f2ad086dd54afef45abc7c5", siteToken: "dafd69ae431245e59bf2658de918385d", hreflang: null },
+  { tld: "essentials.net",   zoneId: "d2bb7fe3fdb1217b844ef3c61deaf7e0", siteToken: "af1f8e9509494fdc9296748bccfa4f67", hreflang: null },
   { tld: "essentials.eu",    zoneId: "75a68625aff272cfcd14be528568774e", siteToken: "ea6290a203dd479eb29129f67a63a707", hreflang: "de" },
   { tld: "essentials.us",    zoneId: "0030f0ca87bb371396df88f626f40f51", siteToken: "0cf65acf96c340bf97f088b639741fac", hreflang: "en-US" },
   { tld: "essentials.fr",    zoneId: "51bd9812a67450597344caaba49dcf0c", siteToken: "2a2a52689b9846b2b982cf22cd060758", hreflang: "fr" },
   { tld: "essentials.cn",    zoneId: "9c657d9a33c65cf08f7388bac27567fb", siteToken: "91fea634621d4b7a8603cabadaf4d669", hreflang: "zh-CN", dnsUnavailable: true },
   { tld: "essentials.hk",    zoneId: "eba3476c1545e7921a74afd94910ef7a", siteToken: "81b6f31ee014450c92c7941f3d963d9b", hreflang: "zh-HK" },
   { tld: "essentials.tw",    zoneId: "fa860897d24799154c196c1a3df49d68", siteToken: "ced9f723c52f4518928c063a63151baa", hreflang: "zh-TW" },
-  { tld: "essentials.mobi",  zoneId: "dc698847dff06bf68ff8356605228d82", siteToken: "141ccb0338744ec5aa52bc614d034937", hreflang: "en" },
+  { tld: "essentials.mobi",  zoneId: "dc698847dff06bf68ff8356605228d82", siteToken: "141ccb0338744ec5aa52bc614d034937", hreflang: null },
 ];
 
 /**
@@ -71,7 +71,7 @@ export function getZones() {
 /**
  * Domain list for the front-end UI (name, url, canonical, hreflang).
  * Domains with dnsUnavailable link to essentials.com instead.
- * @returns {Array<{name: string, url: string, canonical: string, hreflang: string}>}
+ * @returns {Array<{name: string, url: string, canonical: string, hreflang: string|null}>}
  */
 export function getAllDomains() {
   return DOMAINS.map(d => {


### PR DESCRIPTION
## Summary

- Remove duplicate `hreflang` attributes that mapped multiple URLs to the same language-region code, violating Google's hreflang guidelines
- Set `hreflang: null` in `workers/domains.js` for `.net`, `.uk`, and `.mobi` (they don't represent unique language-regions)
- Remove the three corresponding `<link rel="alternate">` tags from `index.html`

## Problem

Google guidelines state: "do not specify more than one URL for the same language-region combination." Previously:

| hreflang code | URLs (before) |
|---|---|
| `en` | `.com`, `.net`, `.uk`, `.mobi` |
| `en-GB` | `.co.uk` |

This sent conflicting signals to search engines about which URL is canonical for English content.

## Fix

| hreflang code | URL (after) |
|---|---|
| `en` | `.com` only |
| `en-GB` | `.co.uk` only |
| `.net`, `.uk`, `.mobi` | `null` (no hreflang tag) |

All other hreflang mappings (`de`, `en-US`, `fr`, `zh-CN`, `zh-HK`, `zh-TW`, `x-default`) are unchanged — they were already 1:1.

Closes #30

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed hreflang alternates for three domains (essentials.uk, essentials.net, essentials.mobi)
  * Updated domain configuration to support optional hreflang values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->