### PR TITLE
fix: remove redundant PNG favicon links

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,9 +20,6 @@
     <link rel="alternate" hreflang="zh-HK" href="https://www.essentials.hk/" />
     <link rel="alternate" hreflang="zh-TW" href="https://www.essentials.tw/" />
     <link rel="alternate" hreflang="x-default" href="https://www.essentials.com/" />
-    <link rel="icon" type="image/png" sizes="48x48" href="/favicon-48x48.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png">


### PR DESCRIPTION
## Summary

- Remove three redundant PNG favicon `<link>` declarations (48x48, 32x32, 16x16) from `index.html`
- The multi-size `favicon.ico` (created in PR #4) already contains all three sizes, making the separate PNG links unnecessary
- Keeps apple-touch-icon and Android Chrome icons (different sizes/purposes)

## Context

Addresses unactioned review feedback from `gemini-code-assist` on PR #4 ([review comment](https://github.com/essentials-com/essentials.com/pull/4#discussion_r2688871479)).

Closes #27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed favicon references from HTML metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->