### PR TITLE
fix: reorder icon links for optimal browser compatibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,10 +20,10 @@
     <link rel="alternate" hreflang="zh-HK" href="https://www.essentials.hk/" />
     <link rel="alternate" hreflang="zh-TW" href="https://www.essentials.tw/" />
     <link rel="alternate" hreflang="x-default" href="https://www.essentials.com/" />
-    <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png">
     <link rel="icon" type="image/png" sizes="512x512" href="/android-chrome-512x512.png">
+    <link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png">
+    <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <meta name="theme-color" content="#000000">
     <meta name="msapplication-TileColor" content="#000000">
     <meta property="og:title" content="ESSENTIALS.COM">


### PR DESCRIPTION
## Summary

- Reorder `<link>` icon declarations in `index.html` so high-resolution/specific icons appear before the general `favicon.ico` fallback
- Order: apple-touch-icon (180x180) → android-chrome (512x512) → android-chrome (192x192) → favicon.ico
- Ensures modern browsers pick the best available icon while older browsers still fall back to favicon.ico

Addresses Gemini code review feedback from PR #47.

Closes #48

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized application icon and favicon asset declarations in the HTML configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->