### PR TITLE
t056: simplify CSP nonce conditional in buildCsp()

### DIFF
--- a/workers/essentials-proxy.js
+++ b/workers/essentials-proxy.js
@@ -31,12 +31,9 @@ const cspBase = [
  * no nonce is needed and a restrictive static policy is used.
  */
 function buildCsp(nonce) {
-  const scriptSrc = nonce
-    ? `script-src 'self' 'nonce-${nonce}' https://analytics.ahrefs.com https://static.cloudflareinsights.com`
-    : "script-src 'self' https://analytics.ahrefs.com https://static.cloudflareinsights.com";
-  const styleSrc = nonce
-    ? `style-src 'self' 'nonce-${nonce}' https://fonts.googleapis.com`
-    : "style-src 'self' https://fonts.googleapis.com";
+  const nonceToken = nonce ? `'nonce-${nonce}' ` : "";
+  const scriptSrc = `script-src 'self' ${nonceToken}https://analytics.ahrefs.com https://static.cloudflareinsights.com`;
+  const styleSrc = `style-src 'self' ${nonceToken}https://fonts.googleapis.com`;
 
   return [...cspBase, scriptSrc, styleSrc].join("; ");
 }


### PR DESCRIPTION
## Summary

- Extracts the repeated nonce ternary in `buildCsp()` into a single `nonceToken` variable, eliminating duplication of base URLs in `scriptSrc` and `styleSrc`
- Functionally identical output verified for both nonce and no-nonce paths

## Review Finding Addressed

| # | Severity | Reviewer | Finding | Resolution |
|---|----------|----------|---------|------------|
| 1 | MEDIUM | Gemini | `scriptSrc` and `styleSrc` ternaries duplicate base URLs — use template literals with inline conditional | Extracted `nonceToken` variable; each URL appears once |

[View original comment](https://github.com/essentials-com/essentials.com/pull/36#discussion_r2893443622)

Closes #56

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code structure and maintainability with no impact on user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->