### PR TITLE
t055: log non-OK HTTP responses when fetching stats.json SHA

### DIFF
--- a/workers/essentials-stats.js
+++ b/workers/essentials-stats.js
@@ -161,6 +161,8 @@ async function updateStats(env) {
     if (getFile.ok) {
       const fileData = await getFile.json();
       sha = fileData.sha;
+    } else {
+      console.error(`Failed to fetch stats.json SHA: HTTP ${getFile.status} ${getFile.statusText}`);
     }
   } catch (e) {
     console.error("Failed to fetch existing stats.json SHA:", e);


### PR DESCRIPTION
## Summary

- Add `else` block to log HTTP status when GitHub API returns non-OK response for `stats.json` SHA fetch
- Addresses Gemini review feedback from PR #35: silent failure when `getFile.ok` is `false` made root cause debugging difficult
- The worker now logs `HTTP {status} {statusText}` server-side before proceeding with `sha=null`

## Context

When the GitHub API returns a non-OK status (e.g., 401 Unauthorized, 500 Internal Server Error), the `if (getFile.ok)` check on line 161 would silently skip SHA extraction. The worker would then attempt to commit without a SHA, resulting in a 409 Conflict — with no log entry pointing to the actual cause (the failed SHA fetch).

The existing `catch` block only handles network-level errors (DNS failure, timeout). This `else` block covers HTTP-level errors (the request succeeded but the server returned an error status).

Closes #55

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error handling with more detailed logging when operations fail, providing better visibility into issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->