### PR TITLE
t049: Generate hreflang tags dynamically via proxy worker

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,15 +11,7 @@
     <meta name="googlebot" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1">
     <meta name="bingbot" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1">
     <link rel="canonical" href="https://www.essentials.com/">
-    <link rel="alternate" hreflang="en" href="https://www.essentials.com/" />
-    <link rel="alternate" hreflang="en-GB" href="https://www.essentials.co.uk/" />
-    <link rel="alternate" hreflang="de" href="https://www.essentials.eu/" />
-    <link rel="alternate" hreflang="en-US" href="https://www.essentials.us/" />
-    <link rel="alternate" hreflang="fr" href="https://www.essentials.fr/" />
-    <link rel="alternate" hreflang="zh-CN" href="https://www.essentials.com/" />
-    <link rel="alternate" hreflang="zh-HK" href="https://www.essentials.hk/" />
-    <link rel="alternate" hreflang="zh-TW" href="https://www.essentials.tw/" />
-    <link rel="alternate" hreflang="x-default" href="https://www.essentials.com/" />
+    <!-- hreflang tags injected dynamically by essentials-proxy worker from workers/domains.js -->
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="512x512" href="/android-chrome-512x512.png">
     <link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png">

--- a/workers/README.md
+++ b/workers/README.md
@@ -14,7 +14,7 @@ To add or remove a domain, edit the `DOMAINS` array in `domains.js`. All consume
 
 ### essentials-proxy
 
-Serves content from the primary domain (www.essentials.com) to all domain aliases. Injects per-domain Cloudflare Web Analytics beacons. Imports `getValidHosts()` and `getSiteTokens()` from `domains.js`.
+Serves content from the primary domain (www.essentials.com) to all domain aliases. Injects per-domain Cloudflare Web Analytics beacons and hreflang alternate links. Imports `getValidHosts()`, `getSiteTokens()`, and `getAllDomains()` from `domains.js`.
 
 **Deploy:**
 ```bash

--- a/workers/essentials-proxy.js
+++ b/workers/essentials-proxy.js
@@ -1,7 +1,29 @@
-import { getValidHosts, getSiteTokens } from "./domains.js";
+import { getValidHosts, getSiteTokens, getAllDomains } from "./domains.js";
 
 const validHosts = getValidHosts();
 const siteTokens = getSiteTokens();
+
+// Build hreflang link tags once at init from the single source of truth (domains.js).
+// These are identical for every response — the full set of language-region alternates
+// plus x-default. Domains with hreflang: null are skipped (no unique language-region).
+const hreflangHtml = (() => {
+  const domains = getAllDomains();
+  let links = "";
+  let defaultHref = "";
+  for (const domain of domains) {
+    if (domain.hreflang) {
+      links += `<link rel="alternate" hreflang="${domain.hreflang}" href="${domain.url}" />\n`;
+    }
+    // The primary domain (ESSENTIALS.COM) is x-default
+    if (domain.name === "ESSENTIALS.COM") {
+      defaultHref = domain.url;
+    }
+  }
+  if (defaultHref) {
+    links += `<link rel="alternate" hreflang="x-default" href="${defaultHref}" />\n`;
+  }
+  return links;
+})();
 
 // Static security headers applied to all responses
 const securityHeaders = {
@@ -170,10 +192,17 @@ Sitemap: https://${wwwHost}/sitemap.xml`;
     const beaconScript = `<script nonce="${nonce}" data-cfasync="false" defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='${JSON.stringify(beaconConfig)}'></script>`;
 
     // Use HTMLRewriter to:
-    // 1. Remove any existing Cloudflare beacon scripts (auto-injected by Cloudflare for essentials.com)
-    // 2. Add nonce attributes to all inline <script> and <style> elements (CSP compliance)
-    // 3. Inject the correct beacon for this domain (with nonce)
+    // 1. Inject hreflang alternate links into <head> (generated from domains.js)
+    // 2. Remove any existing Cloudflare beacon scripts (auto-injected by Cloudflare for essentials.com)
+    // 3. Add nonce attributes to all inline <script> and <style> elements (CSP compliance)
+    // 4. Inject the correct beacon for this domain (with nonce)
     const rewriter = new HTMLRewriter()
+      .on("head", {
+        element(element) {
+          // Inject hreflang links after the opening <head> tag
+          element.append(hreflangHtml, { html: true });
+        },
+      })
       .on("script[src*='cloudflareinsights.com/beacon']", {
         element(element) {
           // Remove auto-injected beacon scripts


### PR DESCRIPTION
## Summary

- Remove hardcoded hreflang `<link>` tags from `index.html` and generate them dynamically in the `essentials-proxy` Cloudflare Worker using `HTMLRewriter`
- Hreflang tags are now sourced from `workers/domains.js` (the single source of truth), eliminating the maintenance burden of keeping `index.html` in sync when domain config changes
- Tags are computed once at worker init (not per-request) for zero runtime overhead

## How it works

1. **`workers/essentials-proxy.js`** now imports `getAllDomains()` from `domains.js` and builds the full set of hreflang `<link>` tags at module init
2. The `HTMLRewriter` injects these tags into `<head>` on every HTML response
3. Domains with `hreflang: null` (`.net`, `.uk`, `.mobi`) are correctly skipped
4. `x-default` points to `essentials.com` (the primary domain)
5. `essentials.cn` (`dnsUnavailable: true`) correctly maps `zh-CN` to the fallback URL (`https://www.essentials.com/`)

## Verification

The generated output is identical to the previously hardcoded tags:
- `en` → `https://www.essentials.com/`
- `en-GB` → `https://www.essentials.co.uk/`
- `de` → `https://www.essentials.eu/`
- `en-US` → `https://www.essentials.us/`
- `fr` → `https://www.essentials.fr/`
- `zh-CN` → `https://www.essentials.com/` (fallback for unavailable DNS)
- `zh-HK` → `https://www.essentials.hk/`
- `zh-TW` → `https://www.essentials.tw/`
- `x-default` → `https://www.essentials.com/`

## Post-merge

After merging, redeploy the proxy worker:
```bash
wrangler deploy -c wrangler-proxy.toml
```

Closes #49

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved multi-language and multi-region content handling by transitioning variant metadata from static configuration to dynamic injection, enabling more flexible and maintainable support for language alternate links across all supported regions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->