### PR TITLE
fix: add unsafe-inline to style-src CSP for JS-set inline styles

### DIFF
--- a/workers/essentials-proxy.js
+++ b/workers/essentials-proxy.js
@@ -55,7 +55,10 @@ const cspBase = [
 function buildCsp(nonce) {
   const nonceToken = nonce ? `'nonce-${nonce}' ` : "";
   const scriptSrc = `script-src 'self' ${nonceToken}https://analytics.ahrefs.com https://static.cloudflareinsights.com`;
-  const styleSrc = `style-src 'self' ${nonceToken}https://fonts.googleapis.com`;
+  // 'unsafe-inline' is required because chart JS sets element.style properties
+  // (conic-gradient on pie chart, segment heights, tooltip positioning) which
+  // cannot carry nonces. The nonce still protects <style> elements.
+  const styleSrc = `style-src 'self' 'unsafe-inline' ${nonceToken}https://fonts.googleapis.com`;
 
   return [...cspBase, scriptSrc, styleSrc].join("; ");
 }


### PR DESCRIPTION
## Summary

- Fix browser pie chart not rendering on the live site due to CSP blocking inline styles
- Add `'unsafe-inline'` to the `style-src` CSP directive in the proxy worker
- The pie chart's `conic-gradient`, bar chart segment heights/colors, and tooltip positioning are all set via JavaScript `element.style.*` properties, which cannot carry CSP nonces

## Root Cause

The proxy worker's `buildCsp()` function generates a `style-src` directive that only allows `'self'`, a nonce token, and `fonts.googleapis.com`. The HTMLRewriter correctly adds nonces to `<style>` elements, but **inline `style` attributes** set by JavaScript DOM manipulation (`element.style.background = 'conic-gradient(...)'`) cannot carry nonces — they require `'unsafe-inline'` in `style-src`.

This caused 18 CSP violations per page load, making the browser pie chart circle invisible (the legend and total still showed because those use text nodes, not inline styles).

## Fix

Added `'unsafe-inline'` to `style-src` in `workers/essentials-proxy.js:61`. The nonce mechanism still protects `<style>` elements — `'unsafe-inline'` is only needed for JS-set `style` attributes.

## Testing

- Verified via Playwright that the live site shows 18 CSP `style-src` violations
- Confirmed `stats.json` loads successfully (HTTP 200) with valid browser data
- Confirmed the pie chart DOM is constructed correctly but the `conic-gradient` style is stripped by CSP
- After this fix deploys, the pie chart will render correctly

## Deploy Notes

After merge, redeploy the proxy worker and purge Cloudflare cache:

```bash
cd workers && wrangler deploy -c wrangler-proxy.toml
# Then purge cache for all domains in Cloudflare dashboard
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue preventing chart visualizations from rendering correctly due to security policy restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->