### PR TITLE
fix: remove nonce from style-src so unsafe-inline takes effect

### DIFF
--- a/workers/essentials-proxy.js
+++ b/workers/essentials-proxy.js
@@ -57,8 +57,10 @@ function buildCsp(nonce) {
   const scriptSrc = `script-src 'self' ${nonceToken}https://analytics.ahrefs.com https://static.cloudflareinsights.com`;
   // 'unsafe-inline' is required because chart JS sets element.style properties
   // (conic-gradient on pie chart, segment heights, tooltip positioning) which
-  // cannot carry nonces. The nonce still protects <style> elements.
-  const styleSrc = `style-src 'self' 'unsafe-inline' ${nonceToken}https://fonts.googleapis.com`;
+  // cannot carry nonces. Per CSP Level 3, 'unsafe-inline' is ignored when a
+  // nonce is present, so we intentionally omit the nonce from style-src.
+  // The nonce on script-src still protects against XSS via inline scripts.
+  const styleSrc = `style-src 'self' 'unsafe-inline' https://fonts.googleapis.com`;
 
   return [...cspBase, scriptSrc, styleSrc].join("; ");
 }


### PR DESCRIPTION
## Summary

- Follow-up to PR #61 — the `'unsafe-inline'` added to `style-src` was being ignored because a nonce was also present
- Per CSP Level 3 spec, when a nonce is present in a directive, `'unsafe-inline'` is silently dropped by the browser
- Fix: remove the nonce from `style-src`, keeping it only on `script-src` where it provides XSS protection

## Root Cause

PR #61 correctly identified that `'unsafe-inline'` was needed in `style-src` for JS-set inline styles. However, the `buildCsp()` function was also including a nonce token in `style-src`:

```
style-src 'self' 'unsafe-inline' 'nonce-xxx' https://fonts.googleapis.com
```

Per [CSP Level 3 spec](https://www.w3.org/TR/CSP3/#match-element-to-source-list), when a nonce or hash is present in a source list, `'unsafe-inline'` is ignored. This is a security feature — nonces are stricter than `'unsafe-inline'`, so the browser assumes you want nonce-only enforcement.

The result: 18 CSP `style-src-attr` violations per page load, and the pie chart remained invisible even after PR #61.

## Fix

Remove the nonce from `style-src` while keeping it on `script-src`:

```js
// Before (nonce causes unsafe-inline to be ignored):
const styleSrc = `style-src 'self' 'unsafe-inline' 'nonce-${nonce}' https://fonts.googleapis.com`;

// After (unsafe-inline works as intended):
const styleSrc = `style-src 'self' 'unsafe-inline' https://fonts.googleapis.com`;
```

The nonce on `script-src` still protects against XSS via inline scripts. Inline styles are a lower security risk and `'unsafe-inline'` is the standard approach when JavaScript DOM manipulation sets `element.style` properties.

## Testing

- Verified via Playwright that the pie chart was still invisible after PR #61 deployed
- Confirmed 18 CSP `style-src-attr` violations in browser console
- After this fix, `style-src` will be `'self' 'unsafe-inline' https://fonts.googleapis.com` (no nonce), allowing JS-set inline styles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Content Security Policy (CSP) handling for inline styles. The style-src directive no longer includes a nonce token, aligning with CSP Level 3 specifications where 'unsafe-inline' takes precedence. Script nonces continue to function as intended, ensuring accurate security policy enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->