### PR TITLE
chore: clarify browser chart subtitle

### DIFF
--- a/index.html
+++ b/index.html
@@ -1192,7 +1192,7 @@
     <section class="traffic-section" id="browser-section">
         <div class="traffic-header">
             <h2>Browsers</h2>
-            <div class="source">(7-day average daily pageviews. Real users only, bots excluded.)</div>
+            <div class="source">(7-day average daily pageviews. Bots and unknown browsers excluded.)</div>
         </div>
         <div class="browser-chart" id="browser-chart"></div>
     </section>


### PR DESCRIPTION
## Summary

- Update browser pie chart subtitle from "Real users only, bots excluded." to "Bots and unknown browsers excluded."
- The chart filters out both bots (GoogleBot, BingBot, etc.) and the "Unknown" browser category, which accounts for ~40% of raw pageviews — this explains why the pie chart total appears lower than the unique visitors count above it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the pageviews metric description to specify that both bots and unknown browsers are excluded from the 7-day average calculation, providing users with more precise information about the data being presented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->