### PR TITLE
GH#80: add Worker Guidance to AGENTS.md for recurring error patterns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,3 +109,41 @@ The `/day`, `/week`, `/month`, `/year` stats are calculated from **complete days
 - After making changes, purge Cloudflare cache for affected domains
 - Zone IDs and Web Analytics tokens are public identifiers (not secrets)
 - Actual API secrets stored via `wrangler secret put` (CF_API_TOKEN, GITHUB_TOKEN)
+
+## Worker Guidance
+
+Recurring error patterns observed in this repo (from contributor-insight tracking). Address these before starting any edit session.
+
+### File Discovery (prevents `read:file_not_found`)
+
+Always verify file paths before reading. Use `git ls-files` — do not guess paths.
+
+Confirmed tracked files for common tasks:
+
+```
+index.html                  — UI, CSS, JS (single file, ~80KB)
+workers/domains.js          — domain config (single source of truth)
+workers/essentials-proxy.js — proxy Worker source
+workers/essentials-stats.js — stats Worker source
+workers/wrangler-proxy.toml — proxy wrangler config
+workers/wrangler-stats.toml — stats wrangler config
+workers/README.md           — Worker deployment guide
+AGENTS.md                   — this file
+TODO.md                     — task tracking
+```
+
+`stats.json` lives on the `stats` branch, not `main`. Do not attempt to read it from the working tree unless on that branch.
+
+### Read Before Edit (prevents `edit:not_read_first` and `edit:edit_stale_read`)
+
+1. **Always read a file before editing it** — even if you believe you know its contents.
+2. **Re-read after any other tool modifies the same file** — another bash command or edit invalidates your prior read.
+3. **`index.html` is large (~80KB).** Read only the section you need using offset/limit. Provide at least 5 lines of surrounding context in `oldString` for edits.
+4. **`workers/domains.js` is the single source of truth.** Any domain-related change starts here; downstream files import from it and should not be modified directly for domain config.
+
+### Common Bash Pitfalls (reduces `bash:other`)
+
+- Worker files use ES module syntax (`import`/`export`). Do not run them with Node.js directly; use `wrangler dev` for local testing.
+- `wrangler` commands require `CF_API_TOKEN` set in the environment or via `wrangler secret`. Never hardcode tokens.
+- GitHub Pages serves from `main` branch root. Changes to `index.html` are live after push (within ~30s CDN propagation).
+- Cloudflare cache purge after edits: requires `CF_API_TOKEN` and the Zone ID from `workers/domains.js`.


### PR DESCRIPTION
## Summary

Addresses contributor-insight issue #80 which recorded 4 recurring error patterns from worker sessions in this repo:

- `edit:not_read_first` — 71x across 3 models
- `bash:other` — 65x across 3 models
- `edit:edit_stale_read` — 32x across 3 models
- `read:file_not_found` — 24x across 4 models

## Changes

Adds a **Worker Guidance** section to `AGENTS.md` with three subsections:

1. **File Discovery** — lists confirmed tracked file paths to prevent `read:file_not_found`; notes that `stats.json` lives on the `stats` branch
2. **Read Before Edit** — explicit rules addressing `edit:not_read_first` and `edit:edit_stale_read`, including `index.html` size warning and 5-line context requirement
3. **Common Bash Pitfalls** — project-specific guidance for `bash:other`: ES module syntax, wrangler token requirements, GH Pages propagation, cache purge requirements

## Files

- EDIT: `AGENTS.md` — added Worker Guidance section at end of file (38 lines)

## Verification

`git ls-files AGENTS.md` confirms file is tracked; diff is doc-only with no functional changes.

For #80


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.93 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-sonnet-4-6 spent 4m and 9,725 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Worker Guidance section to contributor documentation, including file discovery best practices, version control procedures, workflow guidelines, and common troubleshooting tips for project development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->