### PR TITLE
GH#82: add Git Workflow section to AGENTS.md Worker Guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,6 +141,15 @@ TODO.md                     — task tracking
 3. **`index.html` is large (~80KB).** Read only the section you need using offset/limit. Provide at least 5 lines of surrounding context in `oldString` for edits.
 4. **`workers/domains.js` is the single source of truth.** Any domain-related change starts here; downstream files import from it and should not be modified directly for domain config.
 
+### Git Workflow (prevents direct-main edits)
+
+All code changes go through a worktree and PR — never directly on `main`. No exceptions.
+
+- Interactive sessions: `wt switch -c feature/<name>` from the canonical repo on `main` creates a linked worktree at `~/Git/essentials.com-<branch-name>/`.
+- Headless workers: the dispatcher pre-creates the worktree; `$WORKER_WORKTREE_PATH` is set in the environment. If not set, create one via `worktree-helper.sh add`.
+- The canonical directory (`~/Git/essentials.com/`) stays on `main` always.
+- `TODO.md`, `AGENTS.md`, and `README.md` edits from headless sessions may be pushed to `main` directly (planning exception), but code and worker edits always need a PR.
+
 ### Common Bash Pitfalls (reduces `bash:other`)
 
 - Worker files use ES module syntax (`import`/`export`). Do not run them with Node.js directly; use `wrangler dev` for local testing.


### PR DESCRIPTION
## Summary

Add explicit Git Workflow section to AGENTS.md Worker Guidance, incorporating the actionable contributor-insight candidate from issue #82.

## Changes

- EDIT: `AGENTS.md` — added `### Git Workflow` subsection to Worker Guidance with explicit worktree/PR requirements, canonical directory rule, and planning-file exception for headless workers

## Triage Notes

Reviewed all 8 candidates from issue #82:
- **Candidate 5 actioned**: "we always work on worktrees from main, no exceptions" — added as explicit project-level documentation
- **Candidates 1, 2, 3, 4, 6, 7, 8 not actioned here**: These are aidevops framework topics (GitLab/Gitea support, Shopify MCP, OpenCode routing, mitmproxy, pulse locking, MRCR benchmarks, signature footers) — not relevant to the essentials.com project AGENTS.md

## Verification

```bash
git diff origin/main AGENTS.md | grep -A 10 'Git Workflow'
```

Resolves #82


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.94 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-sonnet-4-6 spent 2m and 6,411 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor workflow documentation with new Git workflow guidelines, including required use of worktrees and pull requests for code changes while allowing direct updates to specific documentation files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->