### PR TITLE
GH#85: fix AGENTS.md inconsistencies from PR #84 review feedback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,10 +143,10 @@ TODO.md                     — task tracking
 
 ### Git Workflow (prevents direct-main edits)
 
-All code changes go through a worktree and PR — never directly on `main`. No exceptions.
+All code changes go through a worktree and PR — never directly on `main`, except for the planning files noted below.
 
 - Interactive sessions: `wt switch -c feature/<name>` from the canonical repo on `main` creates a linked worktree at `~/Git/essentials.com-<branch-name>/`.
-- Headless workers: the dispatcher pre-creates the worktree; `$WORKER_WORKTREE_PATH` is set in the environment. If not set, create one via `worktree-helper.sh add`.
+- Headless workers: the dispatcher pre-creates the worktree; `$WORKER_WORKTREE_PATH` is set in the environment. If not set, create one via `worktree-helper.sh add` (external aidevops framework tool — not tracked in this repo; available at `~/.aidevops/agents/scripts/worktree-helper.sh`).
 - The canonical directory (`~/Git/essentials.com/`) stays on `main` always.
 - `TODO.md`, `AGENTS.md`, and `README.md` edits from headless sessions may be pushed to `main` directly (planning exception), but code and worker edits always need a PR.
 


### PR DESCRIPTION
## Summary

Addresses two AGENTS.md inconsistencies flagged by Gemini in PR #84 review.

### Finding 1 — Contradictory "No exceptions" (line 146)

The phrase "No exceptions." directly contradicted line 151, which documents a planning exception for headless sessions (direct pushes to `main` for `TODO.md`, `AGENTS.md`, `README.md`). Replaced with: "except for the planning files noted below."

### Finding 2 — Ambiguous `worktree-helper.sh` reference (line 149)

`worktree-helper.sh` was referenced as a tool to create worktrees but was absent from the "Confirmed tracked files" list. Agents following `git ls-files` instructions would fail to locate it. Added a parenthetical clarifying it is an external aidevops framework tool with its actual path (`~/.aidevops/agents/scripts/worktree-helper.sh`).

### Verification

Both edits are doc-only (no code changes). The section reads consistently end-to-end with no contradictions.

Resolves #85
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.95 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-sonnet-4-6 spent 1m and 2,481 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified workflow rules for the main branch, adding explicit exceptions for planning files.
  * Improved documentation for headless worker configuration, including external framework tool integration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->