### PR TITLE
GH#89: expand bash pitfalls in AGENTS.md Worker Guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,3 +156,7 @@ All code changes go through a worktree and PR — never directly on `main`, exce
 - `wrangler` commands require `CF_API_TOKEN` set in the environment or via `wrangler secret`. Never hardcode tokens.
 - GitHub Pages serves from `main` branch root. Changes to `index.html` are live after push (within ~30s CDN propagation).
 - Cloudflare cache purge after edits: requires `CF_API_TOKEN` and the Zone ID from `workers/domains.js`.
+- **`workers/domains.js` is JavaScript, not JSON** — do not pipe it to `jq` or parse it with shell JSON tools; they will fail. Use the Read tool to inspect domain configuration directly.
+- **No `package.json` at the repo root** — do not run `npm install` at the project root. Workers have no local npm dependency tree; they run on Cloudflare's runtime.
+- **`stats.json` on `main` is a historical snapshot** — it is not updated in real time. Live stats are served from the `stats` branch. Do not try to update or process `stats.json` from `main`.
+- **`index.html` is ~80KB** — avoid shell text-processing tools (`grep`, `sed`, `awk`, `echo`) on it; they are unreliable at this size. Use the Read tool with `offset`/`limit` to find the section you need, and the Edit tool with `oldString`/`newString` for precise changes.


### PR DESCRIPTION
## Summary

Adds four repo-specific bash pitfalls to AGENTS.md Worker Guidance to reduce `bash:other` errors (84x reported in issue #89).

### Changes

`AGENTS.md` — Worker Guidance `### Common Bash Pitfalls` section extended with:

- `workers/domains.js` is JavaScript not JSON — prevents workers from piping it to `jq` (which fails silently or errors)
- No `package.json` at repo root — prevents `npm install` attempts that fail immediately
- `stats.json` on main is a historical snapshot — prevents workers from treating the main-branch snapshot as live data
- `index.html` is ~80KB — reinforces avoiding shell text tools on large files, directing to Read/Edit tools

### Why

Issue #89 reports `bash:other` at 84x across 2 models — the highest error category. The existing Worker Guidance covered ES module syntax and token requirements, but missed these four repo-specific failure modes that trigger bash tool errors.

Resolves #89


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.10.3 plugin for [OpenCode](https://opencode.ai) v1.14.24 with claude-sonnet-4-6 spent 6m and 15,987 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated developer guidance documentation with additional safety warnings and best practices for repository operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->