### PR TITLE
fix: clarify Cloudflare Workers terminology in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,6 +157,6 @@ All code changes go through a worktree and PR — never directly on `main`, exce
 - GitHub Pages serves from `main` branch root. Changes to `index.html` are live after push (within ~30s CDN propagation).
 - Cloudflare cache purge after edits: requires `CF_API_TOKEN` and the Zone ID from `workers/domains.js`.
 - **`workers/domains.js` is JavaScript, not JSON** — do not pipe it to `jq` or parse it with shell JSON tools; they will fail. Use the Read tool to inspect domain configuration directly.
-- **No `package.json` at the repo root** — do not run `npm install` at the project root. Workers have no local npm dependency tree; they run on Cloudflare's runtime.
+- **No `package.json` at the repo root** — do not run `npm install` at the project root. This repository does not use a local npm dependency tree for its Cloudflare Workers; they are designed to run without external node dependencies.
 - **`stats.json` on `main` is a historical snapshot** — it is not updated in real time. Live stats are served from the `stats` branch. Do not try to update or process `stats.json` from `main`.
 - **`index.html` is ~80KB** — avoid shell text-processing tools (`grep`, `sed`, `awk`, `echo`) on it; they are unreliable at this size. Use the Read tool with `offset`/`limit` to find the section you need, and the Edit tool with `oldString`/`newString` for precise changes.


### PR DESCRIPTION
Clarify 'Workers' terminology in AGENTS.md to remove ambiguity between AI agent workers and Cloudflare Workers, and fix the misleading runtime explanation.

## What changed

`AGENTS.md:160` — updated the no-package.json guidance bullet to:
- Remove 'Workers have no local npm dependency tree; they run on Cloudflare's runtime' (ambiguous subject + technically misleading reason)
- Replace with 'This repository does not use a local npm dependency tree for its Cloudflare Workers; they are designed to run without external node dependencies' (explicit subject, accurate explanation)

## Why

The old phrasing had two problems:
1. **Ambiguous subject**: In AGENTS.md context, 'Workers' primarily refers to AI agent workers. Using 'Workers' to mean Cloudflare Workers code without qualification confuses the reader about which workers are meant.
2. **Misleading technical reason**: Cloudflare Workers _can_ use npm packages. The absence of package.json is a deliberate design choice for this repo, not a platform constraint.

## Verification

The change is documentation only (no code). Verified by reading the updated line.

Resolves #91


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.0 plugin for [OpenCode](https://opencode.ai) v1.14.24 with claude-sonnet-4-6 spent 54s and 1,816 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that Cloudflare Workers are designed to run independently without external Node.js dependencies, ensuring a simpler and more self-contained deployment model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->