### PR TITLE
t93: fix imprecise 'node dependencies' terminology in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,6 +157,6 @@ All code changes go through a worktree and PR — never directly on `main`, exce
 - GitHub Pages serves from `main` branch root. Changes to `index.html` are live after push (within ~30s CDN propagation).
 - Cloudflare cache purge after edits: requires `CF_API_TOKEN` and the Zone ID from `workers/domains.js`.
 - **`workers/domains.js` is JavaScript, not JSON** — do not pipe it to `jq` or parse it with shell JSON tools; they will fail. Use the Read tool to inspect domain configuration directly.
-- **No `package.json` at the repo root** — do not run `npm install` at the project root. This repository does not use a local npm dependency tree for its Cloudflare Workers; they are designed to run without external node dependencies.
+- **No `package.json` at the repo root** — do not run `npm install` at the project root. This repository does not use a local npm dependency tree for its Cloudflare Workers; they are designed to run without external npm packages.
 - **`stats.json` on `main` is a historical snapshot** — it is not updated in real time. Live stats are served from the `stats` branch. Do not try to update or process `stats.json` from `main`.
 - **`index.html` is ~80KB** — avoid shell text-processing tools (`grep`, `sed`, `awk`, `echo`) on it; they are unreliable at this size. Use the Read tool with `offset`/`limit` to find the section you need, and the Edit tool with `oldString`/`newString` for precise changes.


### PR DESCRIPTION
## Summary

Addresses medium-severity review feedback from Gemini on PR #92 ([view comment](https://github.com/essentials-com/essentials.com/pull/92#discussion_r3141744263)).

## Change

**File**: `AGENTS.md:160`

The term "external node dependencies" was imprecise. Cloudflare Workers run on a custom V8-based runtime, not Node.js. Changed to "external npm packages" for accuracy and consistency with the preceding "npm dependency tree" wording in the same sentence.

**Before:**
```
they are designed to run without external node dependencies.
```

**After:**
```
they are designed to run without external npm packages.
```

## Testing

Documentation-only change — no functional code modified. Verified diff targets the correct line.

<!-- MERGE_SUMMARY: Fixed imprecise terminology in AGENTS.md (line 160): replaced 'external node dependencies' with 'external npm packages'. Cloudflare Workers run on a V8-based runtime, not Node.js, so 'npm packages' is more accurate and consistent with the preceding 'npm dependency tree' wording. This addresses the medium-severity Gemini review finding from PR #92. -->

Resolves #93


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.1 plugin for [OpenCode](https://opencode.ai) v1.14.28 with claude-sonnet-4-6 spent 1m and 1,772 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated terminology in installation guidance to clarify best practices for project setup and dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->