### PR TITLE
GH#96: document supervisor dashboard recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,12 @@ wrangler secret put GITHUB_TOKEN -c wrangler-stats.toml
 
 **Note:** Stats are committed to a separate `stats` branch to avoid triggering GitHub Pages rebuilds.
 
+### 4.1 Supervisor Health Dashboard
+
+This repository also has an aidevops supervisor health dashboard issue. The dashboard is refreshed by the local aidevops `stats-wrapper.sh` scheduler, not by the Cloudflare stats Worker.
+
+If the dashboard becomes stale while the launch agent is installed, check `~/.aidevops/logs/stats.log` for `Health issue: skipping creation` lines. That message means the cached dashboard issue pointer is missing or unreadable for the current aidevops identity, so the activity guard may skip resolving the existing pinned dashboard. Restore the relevant `~/.aidevops/logs/health-issue-*essentials-com-essentials.com` cache entry to the dashboard issue number, then run a targeted health dashboard refresh and verify the body contains a current `last_refresh:` marker.
+
 ### 5. Customize
 
 Edit `index.html` to update:


### PR DESCRIPTION
## Summary

Documented the supervisor health dashboard cache/activity-guard stale failure mode after refreshing dashboard #78.

## Files Changed

README.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** stats-wrapper self-check OK; dashboard #78 last_refresh verified as 2026-05-10T00:11:03Z

Resolves #96


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.22 plugin for [OpenCode](https://opencode.ai) v1.14.44 with gpt-5.5 spent 8m and 72,791 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Supervisor Health Dashboard documentation with troubleshooting guidance for addressing stale dashboard data.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/essentials-com/essentials.com/pull/97)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->