### PR TITLE
docs: clarify health dashboard issue recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,9 +119,9 @@ wrangler secret put GITHUB_TOKEN -c wrangler-stats.toml
 
 ### 4.1 Supervisor Health Dashboard
 
-This repository also has an aidevops supervisor health dashboard issue. The dashboard is refreshed by the local aidevops `stats-wrapper.sh` scheduler, not by the Cloudflare stats Worker.
+This repository also uses a GitHub Issue as an aidevops supervisor health dashboard. The dashboard is refreshed by the local aidevops `stats-wrapper.sh` scheduler, not by the Cloudflare stats Worker.
 
-If the dashboard becomes stale while the launch agent is installed, check `~/.aidevops/logs/stats.log` for `Health issue: skipping creation` lines. That message means the cached dashboard issue pointer is missing or unreadable for the current aidevops identity, so the activity guard may skip resolving the existing pinned dashboard. Restore the relevant `~/.aidevops/logs/health-issue-*essentials-com-essentials.com` cache entry to the dashboard issue number, then run a targeted health dashboard refresh and verify the body contains a current `last_refresh:` marker.
+If the dashboard becomes stale while the launch agent is installed, check `~/.aidevops/logs/stats.log` for `Health issue: skipping creation` lines. That message means the cached dashboard issue pointer is missing or unreadable for the current aidevops identity, so the activity guard may skip resolving the existing pinned dashboard. To recover, update the relevant `~/.aidevops/logs/health-issue-*essentials-com-essentials.com` cache file so it contains the numeric GitHub Issue ID for the dashboard, then run a targeted health dashboard refresh and verify the body contains a current `last_refresh:` marker.
 
 ### 5. Customize
 


### PR DESCRIPTION
## Summary
- Clarifies that the aidevops supervisor health dashboard is a GitHub Issue.
- Documents that recovery requires restoring the numeric GitHub Issue ID in the health issue cache file.

## Testing
- Verified README.md diff.
- Reread edited README.md lines 120-124.

Resolves #98

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.25 plugin for [OpenCode](https://opencode.ai) v1.14.46 with gpt-5.5 spent 1m and 32,422 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Supervisor Health Dashboard documentation with clarified GitHub Issue references and refined recovery instructions for stale dashboard scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/essentials-com/essentials.com/pull/99)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->