### PR TITLE
GH#100: docs: clarify GitHub issue number wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ wrangler secret put GITHUB_TOKEN -c wrangler-stats.toml
 
 This repository also uses a GitHub Issue as an aidevops supervisor health dashboard. The dashboard is refreshed by the local aidevops `stats-wrapper.sh` scheduler, not by the Cloudflare stats Worker.
 
-If the dashboard becomes stale while the launch agent is installed, check `~/.aidevops/logs/stats.log` for `Health issue: skipping creation` lines. That message means the cached dashboard issue pointer is missing or unreadable for the current aidevops identity, so the activity guard may skip resolving the existing pinned dashboard. To recover, update the relevant `~/.aidevops/logs/health-issue-*essentials-com-essentials.com` cache file so it contains the numeric GitHub Issue ID for the dashboard, then run a targeted health dashboard refresh and verify the body contains a current `last_refresh:` marker.
+If the dashboard becomes stale while the launch agent is installed, check `~/.aidevops/logs/stats.log` for `Health issue: skipping creation` lines. That message means the cached dashboard issue pointer is missing or unreadable for the current aidevops identity, so the activity guard may skip resolving the existing pinned dashboard. To recover, update the relevant `~/.aidevops/logs/health-issue-*essentials-com-essentials.com` cache file so it contains the GitHub Issue number for the dashboard, then run a targeted health dashboard refresh and verify the body contains a current `last_refresh:` marker.
 
 ### 5. Customize
 


### PR DESCRIPTION
## Summary

Clarified the supervisor health dashboard recovery docs to use GitHub's issue-number terminology instead of internal issue-ID wording.

## Files Changed

README.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Verified README.md no longer contains the outdated phrase and ran git diff --check -- README.md

Resolves #100


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.29 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 5m and 44,658 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Supervisor Health Dashboard troubleshooting guidance to clarify cache file requirements when recovering from stale dashboards during launch agent installation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/essentials-com/essentials.com/pull/101)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->