### PR TITLE
chore: remove essentials.mobi

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,6 @@ To add or remove a domain, edit `workers/domains.js` — all other files import 
 - essentials.cn (DNS unavailable, links to essentials.com, skipped in logo rotation)
 - essentials.hk
 - essentials.tw
-- essentials.mobi
 
 ## Key Files
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ Feel free to fork and use for your own similar needs.
 - [essentials.cn](https://essentials.cn)
 - [essentials.hk](https://essentials.hk)
 - [essentials.tw](https://essentials.tw)
-- [essentials.mobi](https://essentials.mobi)
 
 ## Setup Your Own
 

--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@
             "itemOffered": {
                 "@type": "Intangible",
                 "name": "Essentials Domain Portfolio",
-                "description": "Premium domain collection including essentials.com, essentials.net, essentials.co.uk, essentials.uk, essentials.eu, essentials.us, essentials.fr, essentials.cn, essentials.hk, essentials.tw, and essentials.mobi"
+                "description": "Premium domain collection including essentials.com, essentials.net, essentials.co.uk, essentials.uk, essentials.eu, essentials.us, essentials.fr, essentials.cn, essentials.hk, and essentials.tw"
             },
             "availability": "https://schema.org/InStock",
             "seller": {
@@ -89,7 +89,6 @@
             'essentials.co.uk': 'VWNgkomN2acCUaLVT4WmUw',
             'essentials.tw': 'k1byhRJTemRHLVN3Mr6+CA',
             'essentials.hk': 'O7bX73mR0HaU34LhrRC5ow',
-            'essentials.mobi': 'egUMA2obY3z3CRDlqY3JJw',
             'essentials.net': 'STZ2dHbZL/AQQ5dbtPec1Q',
             'essentials.us': 'ZbLsWd4o4n7zRAXkuK8kEA'
         };
@@ -881,7 +880,6 @@
                 <li>essentials.hk</li>
                 <li>essentials.tw</li>
                 <li>essentials.fr</li>
-                <li>essentials.mobi</li>
             </ul>
             <p>Other essentials. top-level domain names may be available for further acquisitions.</p>
             <p>Contact details or brokerage assistance, for those we have had previous correspondence with, is also available.</p>

--- a/workers/domains.js
+++ b/workers/domains.js
@@ -41,7 +41,6 @@ export const DOMAINS = [
   { tld: "essentials.cn",    zoneId: "9c657d9a33c65cf08f7388bac27567fb", siteToken: "91fea634621d4b7a8603cabadaf4d669", hreflang: "zh-CN", dnsUnavailable: true },
   { tld: "essentials.hk",    zoneId: "eba3476c1545e7921a74afd94910ef7a", siteToken: "81b6f31ee014450c92c7941f3d963d9b", hreflang: "zh-HK" },
   { tld: "essentials.tw",    zoneId: "fa860897d24799154c196c1a3df49d68", siteToken: "ced9f723c52f4518928c063a63151baa", hreflang: "zh-TW" },
-  { tld: "essentials.mobi",  zoneId: "dc698847dff06bf68ff8356605228d82", siteToken: "141ccb0338744ec5aa52bc614d034937", hreflang: null },
 ];
 
 /**


### PR DESCRIPTION
## Summary

- remove `essentials.mobi` from the shared domain configuration
- remove it from site metadata, analytics lookup, portfolio copy, and repository documentation

## Verification

- `git diff --check`
- no tracked `essentials.mobi` references remain
- `node --check workers/domains.js`
- validated all three JSON-LD blocks in `index.html`
- served `index.html` locally and verified the removed domain is absent

## Runtime Testing

Runtime-verified with a local HTTP server; the served page returned HTTP 200, excluded `essentials.mobi`, and retained the remaining portfolio entries.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.180 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 3m and 47,862 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated live demo listings by removing `essentials.mobi` and adding demos for `essentials.cn`, `essentials.hk`, and `essentials.tw`.

* **Bug Fixes**
  * Removed `essentials.mobi` from supported domain lists, portfolio displays, SEO metadata, and related site mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->