### PR TITLE
fix: remove remaining mobi metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ESSENTIALS.COM</title>
-    <meta name="description" content="essentials.com, .net, .co.uk, .uk, .eu, .us, .fr, .cn, .hk, .tw, .mobi - Premium brand rare one-word global domain collection for sale.">
+    <meta name="description" content="essentials.com, .net, .co.uk, .uk, .eu, .us, .fr, .cn, .hk, .tw - Premium brand rare one-word global domain collection for sale.">
     <meta name="keywords" content="essentials, domain, premium domain, domain for sale, one-word domain, brand domain, essentials.com">
     <meta name="author" content="Essentials">
     <meta name="robots" content="index, follow">
@@ -19,7 +19,7 @@
     <meta name="theme-color" content="#000000">
     <meta name="msapplication-TileColor" content="#000000">
     <meta property="og:title" content="ESSENTIALS.COM">
-    <meta property="og:description" content="essentials.com, .net, .co.uk, .uk, .eu, .us, .fr, .cn, .hk, .tw, .mobi - Premium brand rare one-word global domain collection for sale.">
+    <meta property="og:description" content="essentials.com, .net, .co.uk, .uk, .eu, .us, .fr, .cn, .hk, .tw - Premium brand rare one-word global domain collection for sale.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://www.essentials.com/">
     <meta property="og:site_name" content="Essentials">
@@ -39,7 +39,7 @@
         "@type": "WebSite",
         "name": "Essentials",
         "url": "https://www.essentials.com/",
-        "description": "essentials.com, .net, .co.uk, .uk, .eu, .us, .fr, .cn, .hk, .tw, .mobi - Premium brand rare one-word global domain collection for sale.",
+        "description": "essentials.com, .net, .co.uk, .uk, .eu, .us, .fr, .cn, .hk, .tw - Premium brand rare one-word global domain collection for sale.",
         "potentialAction": {
             "@type": "SearchAction",
             "target": "https://www.essentials.com/?q={search_term_string}",


### PR DESCRIPTION
## Summary

- remove the remaining shorthand `.mobi` mentions from page, Open Graph, and structured-data descriptions
- complete the removal started in #104

## Verification

- no tracked `.mobi` references remain
- `git diff --check`
- validated all three JSON-LD blocks in `index.html`
- served `index.html` locally and verified `.mobi` is absent

## Runtime Testing

Runtime-verified with a local HTTP server; the served page returned HTTP 200 with no `.mobi` references.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.180 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 17m and 148,346 tokens on this with the user in an interactive session.
