### PR TITLE
GH#28844: enforce issue-first external pull requests

### DIFF
--- a/.github/workflows/linked-issue-check.yml
+++ b/.github/workflows/linked-issue-check.yml
@@ -1,0 +1,25 @@
+name: Linked Issue Check
+
+# Managed by aidevops framework.
+# Upstream policy lives in:
+# marcusquinn/aidevops/.github/workflows/linked-issue-check-reusable.yml
+# This metadata-only pull_request_target caller never checks out PR-head code.
+#
+# Manage with:
+#   aidevops check-workflows --workflow linked-issue-check
+#   aidevops sync-workflows --workflow linked-issue-check --install-missing
+#
+# Enforce by requiring the "linked-issue-check" status in branch protection or
+# a repository ruleset.
+
+permissions:
+  pull-requests: read
+  statuses: write
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  check:
+    uses: marcusquinn/aidevops/.github/workflows/linked-issue-check-reusable.yml@main

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+# Contributing
+
+<!-- aidevops:issue-first-pr:start -->
+## Issue-first pull requests
+
+If you are not a repository owner, member, or collaborator, create or find a
+GitHub issue for your change **before** opening a pull request. Maintainers
+monitor the issue queue more frequently than unsolicited pull requests, so the
+issue is what puts an external contribution into the review queue.
+
+Include one accepted local issue reference in the PR body: `Closes #NNN`,
+`Fixes #NNN`, `Resolves #NNN`, `For #NNN`, or `Ref #NNN`. Use a closing keyword
+for a leaf change that should close the issue on merge; use `For` or `Ref` for
+parent, research, or non-closing work.
+
+External human-authored PRs without an issue reference are blocked until the
+reference is added. Bot PRs and trusted maintainer task workflows are exempt.
+<!-- aidevops:issue-first-pr:end -->


### PR DESCRIPTION
## Summary

- Install `.github/workflows/linked-issue-check.yml` to validate local issue references on external pull requests.
- Add or refresh the managed issue-first policy in `CONTRIBUTING.md`.

## Why

Maintainers monitor the issue queue more consistently than unsolicited pull requests.
External contributors should create or find a local issue before opening a PR.

## Security

The workflow consumes immutable event metadata only. It does not check out, source,
or execute pull-request head content.

## Verification

- External human PR without an accepted local issue reference: check fails.
- Owner, member, collaborator, and bot PRs: documented exemptions apply.
- Re-running the rollout produces no file changes.

**Classification before**: `NO-WORKFLOW`  
**Ref**: `@main`
**Rollout task**: `GH#28844`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.193 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 1h 47m and 1,315,921 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated checks to verify that pull requests reference a relevant issue.
* **Documentation**
  * Updated contribution guidelines with issue-first pull request requirements and applicable exemptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->